### PR TITLE
Uasc 35/auto hide navbar on home page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,7 +15,6 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import theme from "./theme";
 
 function App() {
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <div style={{ backgroundColor: "darkgray" }}>
@@ -35,6 +34,11 @@ function App() {
                   <Route path="/profile" element={<Profile />} />
                 </Routes>
               </div>
+            </div>
+            <div>
+              <h1 style={{ fontSize: "300px" }}>
+                I just needed to add this so I could test scrolling
+              </h1>
             </div>
           </Router>
         </ThemeProvider>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -37,11 +37,6 @@ function App() {
                 </Routes>
               </div>
             </div>
-            <div>
-              <h1 style={{ fontSize: "300px" }}>
-                I just needed to add this so I could test scrolling
-              </h1>
-            </div>
           </Router>
         </ThemeProvider>
       </div>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,14 +1,46 @@
+import { useEffect, useState, useRef } from "react";
 import { Link } from "react-router-dom";
 
+const navbarStyles = {
+  display: "flex",
+  justifyContent: "space-between",
+  backgroundColor: "lightblue",
+  position: "fixed",
+  top: 0,
+  width: "100%",
+  transition: "opacity 0.5s ease-in-out",
+};
+
 const Navbar = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const navRef = useRef();
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollPos = window.scrollY;
+      const navbarHeight = navRef.current.getBoundingClientRect().height;
+      currentScrollPos > navbarHeight
+        ? setIsVisible(true)
+        : setIsVisible(false);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    // remove event listener after effect has run and before component unmounts
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
   return (
     <nav
+      ref={navRef}
       className="navbar"
-      style={{
-        display: "flex",
-        justifyContent: "space-between",
-        backgroundColor: "lightblue",
-      }}
+      style={
+        isVisible
+          ? { ...navbarStyles, opacity: "1" }
+          : { ...navbarStyles, opacity: "0" }
+      }
     >
       <h1> UASC </h1>
       <div className="links" style={{ display: "flex" }}>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,5 +1,5 @@
-import { useEffect, useState, useRef } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
 
 const navbarStyles = {
   display: "flex",
@@ -12,34 +12,39 @@ const navbarStyles = {
 };
 
 const Navbar = () => {
-  const [isVisible, setIsVisible] = useState(false);
-  const navRef = useRef();
+  const homeLocation = "/";
+  const pageLocation = useLocation().pathname;
+  const onHomePage = pageLocation === homeLocation;
+  const [isVisible, setIsVisible] = useState(!onHomePage);
 
   useEffect(() => {
+    if (!onHomePage) {
+      setIsVisible(true);
+      return;
+    }
+
+    setIsVisible(false);
+
     const handleScroll = () => {
       const currentScrollPos = window.scrollY;
-      const navbarHeight = navRef.current.getBoundingClientRect().height;
-      currentScrollPos > navbarHeight
+      const proportionOfWindowHeight = window.innerHeight * 0.3;
+      currentScrollPos > proportionOfWindowHeight
         ? setIsVisible(true)
         : setIsVisible(false);
     };
 
     window.addEventListener("scroll", handleScroll);
 
-    // remove event listener after effect has run and before component unmounts
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [pageLocation]);
 
   return (
     <nav
-      ref={navRef}
       className="navbar"
       style={
         isVisible
           ? { ...navbarStyles, opacity: "1" }
-          : { ...navbarStyles, opacity: "0" }
+          : { ...navbarStyles, opacity: "0", pointerEvents: "none" }
       }
     >
       <h1> UASC </h1>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -36,7 +36,7 @@ const Navbar = () => {
     window.addEventListener("scroll", handleScroll);
 
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [pageLocation]);
+  }, [onHomePage]);
 
   return (
     <nav

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -2,21 +2,28 @@ import logo from "../assets/2023_logo1-768x262-uasc.png";
 import { Typography } from "@mui/material";
 
 const Home = () => {
-	return (
-		<div>
-			<img src={logo} alt="uasc-logo-large" />
-			<Typography
-				variant="h1"
-				sx={{
-					textTransform: "uppercase",
-					fontWeight: "bold	",
-					color: "white",
-				}}
-			>
-				University of Auckland Snowsports Club
-			</Typography>
-		</div>
-	);
+  return (
+    <>
+      <div>
+        <img src={logo} alt="uasc-logo-large" />
+        <Typography
+          variant="h1"
+          sx={{
+            textTransform: "uppercase",
+            fontWeight: "bold	",
+            color: "white",
+          }}
+        >
+          University of Auckland Snowsports Club
+        </Typography>
+      </div>
+      <div>
+        <h1 style={{ fontSize: "300px" }}>
+          I just needed to add this so I could test scrolling
+        </h1>
+      </div>
+    </>
+  );
 };
 
 export default Home;


### PR DESCRIPTION
Completed:

- Navbar is now sticky so it remains in view as the user continues to scroll down a page.

- Navbar is hidden by default when visiting the home page and is only displayed when the user has scrolled more than a certain proportion (currently set to 30% but can be easily changed) of the view height. The navbar also hides again if the user scrolls back up to the top of the home page.

Notes:

- This behaviour is only present on the home page - on every other page the navbar is shown by default and doesn't show/hide on scroll. 