### PR TITLE
Fix production build of emulator suite

### DIFF
--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -17,7 +17,9 @@ const auth = getAuth(app);
 const db = getFirestore(app);
 
 // use emulator suite if running locally
-connectFirestoreEmulator(db, "localhost", 8080);
-connectAuthEmulator(auth, "http://localhost:9099");
+if (process.env.NODE_ENV === "development") {
+	connectFirestoreEmulator(db, "localhost", 8080);
+	connectAuthEmulator(auth, "http://localhost:9099");
+}
 
 export { auth, db };


### PR DESCRIPTION
We hook into the native feature of create-react-app which sets the `NODE_ENV` environment variable to be `development` when running `npm start`, and `production` when running `npm run build` (as we do when deploying).

This allows us to toggle between using the emulator suite, or the production store.