### PR TITLE
Document requests database

### DIFF
--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -1,0 +1,15 @@
+# Firestore Architecture
+We use [Firestore](https://firebase.google.com/docs/firestore) to manage all the 
+## `requests` collection
+This manages all requests by users to the executive team at UASC.
+
+| **Field** 		| **Type** 	| **Example Value**               	|
+|------------------	|----------	|---------------------------------	|
+| email     		| string   	| name@domain.com                 	|
+| query     		| string   	| Hello, when is your next event? 	|
+| query_type 		| string   	| email                           	|
+| status			| string	| unresolved						|
+| creation_time		| timestamp	| 1970-01-01T00:00:00Z				|
+
+- `queryType` allows for future different query types (for example, making a request to change the dates of a booking).
+- `status` indicates the status of the query for the executive team to see (can be `unresolved`, `resolved`)

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -1,15 +1,41 @@
 # Firestore Architecture
-We use [Firestore](https://firebase.google.com/docs/firestore) to manage all the 
+We use [Firestore](https://firebase.google.com/docs/firestore) to manage the database infrastructure.
+
 ## `requests` collection
 This manages all requests by users to the executive team at UASC.
 
-| **Field**     	| **Type**  	| **Example Value**               	|
-|---------------	|-----------	|---------------------------------	|
-| email         	| string    	| name@domain.com                 	|
-| query         	| string    	| Hello, when is your next event? 	|
-| query_type    	| string    	| email                           	|
-| status        	| string    	| unresolved                      	|
-| creation_time 	| timestamp 	| 1970-01-01T00:00:00Z            	|
+| **Field**       	| **Type**    	| **Example Value**                 	|
+|-----------------	|-------------	|-----------------------------------	|
+| --------------- 	| ----------- 	| --------------------------------- 	|
+| user_id         	| string      	| lVsOjAp06AfD6atT8bnrVEpcdcg2      	|
+| booking_id      	| string      	| 8mYj7rWOMH6hGy4FzMed              	|
+| query           	| string      	| Hello, when is your next event?   	|
+| query_type      	| string      	| cancellation                      	|
+| status          	| string      	| unresolved                        	|
+| creation_time   	| timestamp   	| 1970-01-01T00:00:00Z              	|
 
-- `queryType` allows for future different query types (for example, making a request to change the dates of a booking).
-- `status` indicates the status of the query for the executive team to see (can be `unresolved`, `resolved`)
+- `query_type` allows for future different query types. Possible query types
+are
+	- `cancellation`
+	- `dateChange`
+- `status` indicates the status of the query for the executive team to see (can
+be `unresolved` or `resolved`)
+
+Additional fields may be specified, depending on the `query_type`.
+
+### `cancellation` request
+Has no additional fields specified.
+
+### `dateChange` request
+The following additional fields are specified:
+| **Field**       	| **Type**    	| **Example Value**                 	|
+|-----------------	|-------------	|-----------------------------------	|
+| --------------- 	| ----------- 	| --------------------------------- 	|
+| old_start_date  	| Timestamp   	| 25-07-2023                        	|
+| old_end_date    	| Timestamp   	| 27-07-2023                        	|
+| new_start_date  	| Timestamp   	| 26-07-2023                        	|
+| new_end_date    	| Timestamp   	| 28-07-2023                        	|
+
+Implementors should ensure that the range between
+`old_end_date - old_start_date` and `new_end_date` - `new_start_date` do not
+differ (i.e., the amount of days in the booking does not change).

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -3,13 +3,13 @@ We use [Firestore](https://firebase.google.com/docs/firestore) to manage all the
 ## `requests` collection
 This manages all requests by users to the executive team at UASC.
 
-| **Field** 		| **Type** 	| **Example Value**               	|
-|------------------	|----------	|---------------------------------	|
-| email     		| string   	| name@domain.com                 	|
-| query     		| string   	| Hello, when is your next event? 	|
-| query_type 		| string   	| email                           	|
-| status			| string	| unresolved						|
-| creation_time		| timestamp	| 1970-01-01T00:00:00Z				|
+| **Field**     	| **Type**  	| **Example Value**               	|
+|---------------	|-----------	|---------------------------------	|
+| email         	| string    	| name@domain.com                 	|
+| query         	| string    	| Hello, when is your next event? 	|
+| query_type    	| string    	| email                           	|
+| status        	| string    	| unresolved                      	|
+| creation_time 	| timestamp 	| 1970-01-01T00:00:00Z            	|
 
 - `queryType` allows for future different query types (for example, making a request to change the dates of a booking).
 - `status` indicates the status of the query for the executive team to see (can be `unresolved`, `resolved`)

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -6,7 +6,6 @@ This manages all requests by users to the executive team at UASC.
 
 | **Field**       	| **Type**    	| **Example Value**                 	|
 |-----------------	|-------------	|-----------------------------------	|
-| --------------- 	| ----------- 	| --------------------------------- 	|
 | user_id         	| string      	| lVsOjAp06AfD6atT8bnrVEpcdcg2      	|
 | booking_id      	| string      	| 8mYj7rWOMH6hGy4FzMed              	|
 | query           	| string      	| Hello, when is your next event?   	|
@@ -30,7 +29,6 @@ Has no additional fields specified.
 The following additional fields are specified:
 | **Field**       	| **Type**    	| **Example Value**                 	|
 |-----------------	|-------------	|-----------------------------------	|
-| --------------- 	| ----------- 	| --------------------------------- 	|
 | old_start_date  	| Timestamp   	| 25-07-2023                        	|
 | old_end_date    	| Timestamp   	| 27-07-2023                        	|
 | new_start_date  	| Timestamp   	| 26-07-2023                        	|


### PR DESCRIPTION
Adds some documentation describing the way the `requests` collection is structured in Firestore.

Closes #56 