### PR TITLE
Extend Firestore rules all-read access

### DIFF
--- a/frontend/firestore.rules
+++ b/frontend/firestore.rules
@@ -3,7 +3,7 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
       allow read, write: if
-          request.time < timestamp.date(2023, 8, 31);
+          request.time < timestamp.date(2023, 09, 22);
     }
   }
 }


### PR DESCRIPTION
Extends read access to the Firestore up until October 22th. This should give us enough time until we deploy proper read rules.