### PR TITLE
Display user bookings in profile page

### DIFF
--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -46,11 +46,11 @@ differ (i.e., the amount of days in the booking does not change).
 This manages the link between users and booking IDs, and references the current
 check-in and check-out dates of the booking.
 
-| **Field** | **Type**  | **Example Value**            |
-| --------- | --------- | ---------------------------- |
-| user_id   | string    | lVsOjAp06AfD6atT8bnrVEpcdcg2 |
-| check_in  | Timestamp | 26-07-2023                   |
-| check_out | Timestamp | 26-07-2023                   |
+| **Field** | **Type**  | **Example Value**                   |
+| --------- | --------- | ----------------------------------- |
+| user_id   | Reference | /users/lVsOjAp06AfD6atT8bnrVEpcdcg2 |
+| check_in  | Timestamp | 26-07-2023                          |
+| check_out | Timestamp | 26-07-2023                          |
 
 ## `booking_changes` collection
 

--- a/frontend/src/components/ProfileCalendarCard.js
+++ b/frontend/src/components/ProfileCalendarCard.js
@@ -1,8 +1,51 @@
 import { Card, Typography, CardContent, Stack, Box } from "@mui/material"
 import React from "react"
-import { DateCalendar } from "@mui/x-date-pickers"
+import { DateCalendar, PickersDay } from "@mui/x-date-pickers"
+import { styled } from "@mui/material/styles"
 
-function ProfileCalendarCard() {
+const StyledCalendarDay = styled(PickersDay, {
+  shouldForwardProp: (prop) => prop !== "isBookedDate",
+})(
+  /**
+   *
+   * @param {{isBookedDate: boolean}}
+   * @returns
+   */
+  ({ theme, isBookedDate }) => ({
+    ...(isBookedDate && {
+      backgroundColor: theme.palette.primary[theme.palette.mode],
+      "&:hover, &:focus": {
+        backgroundColor: theme.palette.primary[theme.palette.mode],
+      },
+      borderTopLeftRadius: "50%",
+      borderBottomLeftRadius: "50%",
+      borderTopRightRadius: "50%",
+      borderBottomRightRadius: "50%",
+    }),
+  })
+)
+
+function CalendarDay(props) {
+  const { bookings, ...others } = props
+
+  const isBookedDate = bookings.some((booking) => {
+    const start = booking.data().check_in.toDate()
+    const end = booking.data().check_out.toDate()
+
+    const calendarDate = others.day.toDate()
+
+    return start <= calendarDate && end >= calendarDate
+  })
+
+  return <StyledCalendarDay {...others} isBookedDate={isBookedDate} />
+}
+
+/**
+ * @param {{bookings: Array<Booking>}}
+ */
+function ProfileCalendarCard({ bookings }) {
+  // construct all the dates
+
   return (
     <div>
       <Card
@@ -20,10 +63,19 @@ function ProfileCalendarCard() {
               color="#457CC3"
               sx={{ fontWeight: "900" }}
             >
-              Calendar{" "}
+              Calendar
             </Typography>
-            <Box sx={{}}>
-              <DateCalendar />
+            <Box>
+              <DateCalendar
+                readOnly
+                loading={bookings === undefined}
+                slots={{ day: CalendarDay }}
+                slotProps={{
+                  day: () => ({
+                    bookings,
+                  }),
+                }}
+              />
             </Box>
           </Stack>
         </CardContent>

--- a/frontend/src/components/ProfileCalendarCard.js
+++ b/frontend/src/components/ProfileCalendarCard.js
@@ -7,9 +7,7 @@ const StyledCalendarDay = styled(PickersDay, {
   shouldForwardProp: (prop) => prop !== "isBookedDate",
 })(
   /**
-   *
    * @param {{isBookedDate: boolean}}
-   * @returns
    */
   ({ theme, isBookedDate }) => ({
     ...(isBookedDate && {

--- a/frontend/src/components/ProfileCard.js
+++ b/frontend/src/components/ProfileCard.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   Card,
   Typography,

--- a/frontend/src/components/ProfileCurrentBookings.js
+++ b/frontend/src/components/ProfileCurrentBookings.js
@@ -23,7 +23,8 @@ function SingularBookingDetails({ booking, onRequestChange, index }) {
   return (
     <Stack key={booking._uid} direction="row" justifyContent="space-between">
       <Typography variant="body1" align="left">
-        {new Date(booking.data().check_in.toDate()).toDateString()} to
+        {new Date(booking.data().check_in.toDate()).toDateString()}
+        {" to "}
         {new Date(booking.data().check_out.toDate()).toDateString()}
       </Typography>
       <Button

--- a/frontend/src/components/ProfileCurrentBookings.js
+++ b/frontend/src/components/ProfileCurrentBookings.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 import {
   CardContent,
   Stack,
@@ -12,11 +10,17 @@ import {
 import React from "react"
 import { useState } from "react"
 
+/**
+ * Displays a single booking to be inserted into a Stack.
+ * @param {{ booking: Booking, onRequestChange: React.MouseEventHandler<HTMLAnchorElement>}}
+ * @returns
+ */
 function SingularBookingDetails({ booking, onRequestChange }) {
   return (
     <Stack key={booking._uid} direction="row" justifyContent="space-between">
       <Typography variant="body1" align="left">
-        {new Date(booking.data().check_in).toDateString()} to {new Date(booking.data().check_out).toDateString()}
+        {new Date(booking.data().check_in.toDate()).toDateString()} to{" "}
+        {new Date(booking.data().check_out.toDate()).toDateString()}
       </Typography>
       <Button
         variant="contained"
@@ -35,6 +39,11 @@ function SingularBookingDetails({ booking, onRequestChange }) {
   )
 }
 
+/**
+ * Renders the current bookings the user has.
+ * @param {{bookings: Array<Booking> | undefined}} bookings The current user bookings.
+ * @returns
+ */
 function ProfileCurrentBookings({ bookings }) {
   const [open, setOpen] = useState(false)
 
@@ -73,10 +82,16 @@ function ProfileCurrentBookings({ bookings }) {
             </Typography>
             {!bookings ? (
               "Retrieving bookings..."
+            ) : bookings.length === 0 ? (
+              "You have no bookings currently."
             ) : (
               <Stack spacing={2}>
                 {bookings.map((booking) => (
-                  <SingularBookingDetails key={booking.id} booking={booking} onRequestChange={handleOpen} />
+                  <SingularBookingDetails
+                    key={booking.id}
+                    booking={booking}
+                    onRequestChange={handleOpen}
+                  />
                 ))}
               </Stack>
             )}
@@ -84,7 +99,7 @@ function ProfileCurrentBookings({ bookings }) {
         </CardContent>
       </Card>
 
-			{/* edit details dialog */}
+      {/* edit details dialog */}
       <Dialog
         open={open}
         onClose={handleClose}
@@ -232,8 +247,7 @@ function ProfileCurrentBookings({ bookings }) {
                   }}
                   onClick={handleRequestSubmit}
                 >
-                  {" "}
-                  Request Change{" "}
+                  Request Change
                 </Button>
               </Stack>
             </Stack>

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -1,6 +1,6 @@
 import { db } from "../firebase"
 import React, { useEffect, useState } from "react"
-import { getDocs, where, query, collection } from "firebase/firestore"
+import { getDocs, where, query, collection, doc } from "firebase/firestore"
 import { Stack, Typography } from "@mui/material"
 import "../styles/Profile.css"
 import ProfileCard from "../components/ProfileCard"
@@ -9,26 +9,44 @@ import ProfileCurrentBookings from "../components/ProfileCurrentBookings"
 import ProfileBookingHistory from "../components/ProfileBookingHistory"
 import { useAuthenticatedUser } from "../hooks/useAuthenticatedUser"
 
+/**
+ * Reference to a booking from the Firestore.
+ * @typedef {{ data(): { user_id: string, check_in: require("firebase/firestore").Timestamp, check_out: require("firebase/firestore").Timestamp } }} Booking
+ */
+
 const Profile = () => {
   const [user, userMetadata] = useAuthenticatedUser()
+  /**
+   * @type {[Array<Booking>, React.Dispatch<Array<Booking>>]}
+   */
   const [bookings, setBookings] = useState(undefined)
+
+  /**
+   * Retrieves the current user bookings from firestore.
+   * @param {string} userId
+   */
+  const getBookings = (userId) => {
+    getDocs(
+      query(
+        collection(db, "bookings"),
+        where("user_id", "==", doc(db, "users", userId))
+      )
+    )
+      .then((storeBookings) => {
+        setBookings(storeBookings.docs)
+      })
+      .catch((err) =>
+        console.error(
+          `Failed to retrieve bookings for authenticated user: ${err}`
+        )
+      )
+  }
 
   useEffect(() => {
     if (user) {
       getBookings(user.uid)
     }
   }, [user, userMetadata])
-
-  // todo: early return if we aren't logged in (i.e., user === undefined)
-
-  // Retrieve current bookings from firebase
-  const getBookings = (userId) => {
-    getDocs(query(collection(db, "bookings"), where("user_id", "==", userId)))
-      .then((bookings) => {
-        setBookings(bookings.docs)
-      })
-      .catch(console.error)
-  }
 
   return (
     <div
@@ -60,8 +78,8 @@ const Profile = () => {
             >
               My Bookings
             </Typography>
-            <ProfileCalendarCard />
-            {<ProfileCurrentBookings bookings={bookings} />}
+            <ProfileCalendarCard bookings={bookings} />
+            <ProfileCurrentBookings bookings={bookings} />
             <ProfileBookingHistory />
           </Stack>
         </Stack>


### PR DESCRIPTION
We now display the user bookings on the `/profile` page, which shows:
1. a calendar overview with highlighted dates they have booked
2. a list of all their current bookings (alongside the request changes button)

![image](https://github.com/UoaWDCC/uasc-web/assets/46231745/eed0a7b6-3ce1-4249-9c1f-ad11d30eceba)
