### PR TITLE
store current user in sweet state

### DIFF
--- a/client/src/firebase.ts
+++ b/client/src/firebase.ts
@@ -2,6 +2,7 @@
 import { initializeApp, type FirebaseOptions } from "@firebase/app"
 import { getAuth, connectAuthEmulator } from "@firebase/auth"
 import { getFirestore, connectFirestoreEmulator } from "@firebase/firestore"
+import fetchClient from "services/OpenApiFetchClient"
 import { StoreInstance } from "store/store"
 
 const firebaseConfig: FirebaseOptions = {
@@ -23,8 +24,15 @@ if (import.meta.env.VITE_NODE_ENV !== "production") {
   connectAuthEmulator(auth, "http://localhost:9099")
 }
 
-auth.onIdTokenChanged((user) => {
+auth.onIdTokenChanged(async (user) => {
   StoreInstance.actions.setCurrentUser(user)
+  if (user === null) {
+    StoreInstance.actions.setCurrentUserData(undefined)
+    return
+  }
+  const { data } = await fetchClient.GET("/users/self")
+  const currentUserData = data
+  StoreInstance.actions.setCurrentUserData(currentUserData)
 })
 
 export { auth, db }

--- a/client/src/firebase.ts
+++ b/client/src/firebase.ts
@@ -2,6 +2,7 @@
 import { initializeApp, type FirebaseOptions } from "@firebase/app"
 import { getAuth, connectAuthEmulator } from "@firebase/auth"
 import { getFirestore, connectFirestoreEmulator } from "@firebase/firestore"
+import { UserClaims } from "models/User"
 import fetchClient from "services/OpenApiFetchClient"
 import { StoreInstance } from "store/store"
 
@@ -26,10 +27,16 @@ if (import.meta.env.VITE_NODE_ENV !== "production") {
 
 auth.onIdTokenChanged(async (user) => {
   StoreInstance.actions.setCurrentUser(user)
+
   if (user === null) {
-    StoreInstance.actions.setCurrentUserData(undefined)
+    // suggests a log out
+    StoreInstance.actions.resetCurrentUserState()
     return
   }
+
+  const { claims } = await user.getIdTokenResult()
+  StoreInstance.actions.setCurrentUserClaims(claims as UserClaims)
+
   const { data } = await fetchClient.GET("/users/self")
   const currentUserData = data
   StoreInstance.actions.setCurrentUserData(currentUserData)

--- a/client/src/firebase.ts
+++ b/client/src/firebase.ts
@@ -2,6 +2,7 @@
 import { initializeApp, type FirebaseOptions } from "@firebase/app"
 import { getAuth, connectAuthEmulator } from "@firebase/auth"
 import { getFirestore, connectFirestoreEmulator } from "@firebase/firestore"
+import { StoreInstance } from "store/store"
 
 const firebaseConfig: FirebaseOptions = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -21,5 +22,9 @@ if (import.meta.env.VITE_NODE_ENV !== "production") {
   connectFirestoreEmulator(db, "localhost", 8080)
   connectAuthEmulator(auth, "http://localhost:9099")
 }
+
+auth.onIdTokenChanged((user) => {
+  StoreInstance.actions.setCurrentUser(user)
+})
 
 export { auth, db }

--- a/client/src/firebase.ts
+++ b/client/src/firebase.ts
@@ -32,13 +32,14 @@ auth.onIdTokenChanged(async (user) => {
     return
   }
 
-  StoreInstance.actions.setCurrentUser(user)
+  try {
+    const { claims } = await user.getIdTokenResult()
+    const { data: userData } = await fetchClient.GET("/users/self")
 
-  const { claims } = await user.getIdTokenResult()
-  StoreInstance.actions.setCurrentUserClaims(claims as UserClaims)
-
-  const { data: currentUserData } = await fetchClient.GET("/users/self")
-  StoreInstance.actions.setCurrentUserData(currentUserData)
+    StoreInstance.actions.setCurrentUser(user, userData, claims as UserClaims)
+  } catch (error) {
+    console.error(error)
+  }
 })
 
 export { auth, db }

--- a/client/src/firebase.ts
+++ b/client/src/firebase.ts
@@ -26,19 +26,18 @@ if (import.meta.env.VITE_NODE_ENV !== "production") {
 }
 
 auth.onIdTokenChanged(async (user) => {
-  StoreInstance.actions.setCurrentUser(user)
-
   if (user === null) {
     // suggests a log out
     StoreInstance.actions.resetCurrentUserState()
     return
   }
 
+  StoreInstance.actions.setCurrentUser(user)
+
   const { claims } = await user.getIdTokenResult()
   StoreInstance.actions.setCurrentUserClaims(claims as UserClaims)
 
-  const { data } = await fetchClient.GET("/users/self")
-  const currentUserData = data
+  const { data: currentUserData } = await fetchClient.GET("/users/self")
   StoreInstance.actions.setCurrentUserData(currentUserData)
 })
 

--- a/client/src/models/User.ts
+++ b/client/src/models/User.ts
@@ -1,3 +1,7 @@
 import { components } from "./__generated__/schema"
 
 export type UserAdditionalInfo = components["schemas"]["UserAdditionalInfo"]
+
+export type UserClaims = {
+  role?: "admin" | "member"
+}

--- a/client/src/models/User.ts
+++ b/client/src/models/User.ts
@@ -3,5 +3,6 @@ import { components } from "./__generated__/schema"
 export type UserAdditionalInfo = components["schemas"]["UserAdditionalInfo"]
 
 export type UserClaims = {
-  role?: "admin" | "member"
+  admin?: boolean
+  member?: boolean
 }

--- a/client/src/models/User.ts
+++ b/client/src/models/User.ts
@@ -1,0 +1,3 @@
+import { components } from "./__generated__/schema"
+
+export type UserAdditionalInfo = components["schemas"]["UserAdditionalInfo"]

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,4 +1,5 @@
 import { User } from "firebase/auth"
+import { UserAdditionalInfo } from "models/User"
 import {
   defaultRegistry,
   createStore,
@@ -7,7 +8,11 @@ import {
   createHook
 } from "react-sweet-state"
 
-type State = { current: number; currentUser: User | null }
+type State = {
+  current: number
+  currentUser: User | null // firebase type
+  currentUserData?: UserAdditionalInfo
+}
 
 const initialState: State = {
   current: 1000,
@@ -22,6 +27,11 @@ const actions = {
     (user: User | null): Action<State> =>
     ({ setState }) => {
       setState({ currentUser: user })
+    },
+  setCurrentUserData:
+    (userData: UserAdditionalInfo | undefined): Action<State> =>
+    ({ setState }) => {
+      setState({ currentUserData: userData })
     }
 }
 

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,5 +1,5 @@
 import { User } from "firebase/auth"
-import { UserAdditionalInfo } from "models/User"
+import { UserAdditionalInfo, UserClaims } from "models/User"
 import {
   defaultRegistry,
   createStore,
@@ -9,20 +9,16 @@ import {
 } from "react-sweet-state"
 
 type State = {
-  current: number
   currentUser: User | null // firebase type
   currentUserData?: UserAdditionalInfo
+  currentUserClaims?: UserClaims
 }
 
 const initialState: State = {
-  current: 1000,
   currentUser: null
 }
 
 const actions = {
-  loadInfo:
-    (): Action<State> =>
-    async ({ setState }) => {},
   setCurrentUser:
     (user: User | null): Action<State> =>
     ({ setState }) => {
@@ -32,6 +28,16 @@ const actions = {
     (userData: UserAdditionalInfo | undefined): Action<State> =>
     ({ setState }) => {
       setState({ currentUserData: userData })
+    },
+  setCurrentUserClaims:
+    (userClaims: UserClaims | undefined): Action<State> =>
+    ({ setState }) => {
+      setState({ currentUserClaims: userClaims })
+    },
+  resetCurrentUserState:
+    (): Action<State> =>
+    ({ setState }) => {
+      setState({ currentUserClaims: undefined, currentUserData: undefined })
     }
 }
 

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -14,8 +14,14 @@ type State = {
   currentUserClaims?: UserClaims
 }
 
+const defaultUserState = {
+  currentUser: null,
+  currentUserClaims: undefined,
+  currentUserData: undefined
+}
+
 const initialState: State = {
-  currentUser: null
+  ...defaultUserState
 }
 
 const actions = {
@@ -37,7 +43,7 @@ const actions = {
   resetCurrentUserState:
     (): Action<State> =>
     ({ setState }) => {
-      setState({ currentUserClaims: undefined, currentUserData: undefined })
+      setState({ ...defaultUserState })
     }
 }
 

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -26,19 +26,17 @@ const initialState: State = {
 
 const actions = {
   setCurrentUser:
-    (user: User | null): Action<State> =>
+    (
+      user: User | null,
+      userData: UserAdditionalInfo | undefined,
+      userClaims: UserClaims | undefined
+    ): Action<State> =>
     ({ setState }) => {
-      setState({ currentUser: user })
-    },
-  setCurrentUserData:
-    (userData: UserAdditionalInfo | undefined): Action<State> =>
-    ({ setState }) => {
-      setState({ currentUserData: userData })
-    },
-  setCurrentUserClaims:
-    (userClaims: UserClaims | undefined): Action<State> =>
-    ({ setState }) => {
-      setState({ currentUserClaims: userClaims })
+      setState({
+        currentUser: user,
+        currentUserData: userData,
+        currentUserClaims: userClaims
+      })
     },
   resetCurrentUserState:
     (): Action<State> =>

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,20 +1,28 @@
+import { User } from "firebase/auth"
 import {
+  defaultRegistry,
   createStore,
   Action,
   createContainer,
   createHook
 } from "react-sweet-state"
 
-type State = { current: number }
+type State = { current: number; currentUser: User | null }
 
 const initialState: State = {
-  current: 1000
+  current: 1000,
+  currentUser: null
 }
 
 const actions = {
   loadInfo:
     (): Action<State> =>
-    async ({ setState }) => {}
+    async ({ setState }) => {},
+  setCurrentUser:
+    (user: User | null): Action<State> =>
+    ({ setState }) => {
+      setState({ currentUser: user })
+    }
 }
 
 type Actions = typeof actions
@@ -26,5 +34,7 @@ const Store = createStore<State, Actions>({
   actions,
   containedBy: AppDataContainer
 })
+
+export const StoreInstance = defaultRegistry.getStore(Store)
 
 export const useAppData = createHook(Store)


### PR DESCRIPTION
closes #141 

We now have our user data stored in sweet state.

This is similar to the work @8cw did in the `useAuthenticatedUser` hook, but this one gets triggered on the id token changing for the user in auth

There are two objects stored: `currentUser`, which is a reference to the user object from the firebase auth and `currentUserData`, which is of type `UserAdditionalInfo` (which is similar to the `userMetaData` in the old hook)

to use this user in components, use `const [{currentUser, currentUserData, currentUserClaims}] = useAppData()` (you can exclude properties you aren't using)

from there you can call functions like: `await currentUser.getIdToken(true)` to refresh the user. Or access the information/claims by using `currentUserData`/`currentUserClaims`

