### PR TITLE
Add volta to repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,9 @@
       "<rootDir>/client/jest.config.client.ts",
       "<rootDir>/server/jest.config.server.ts"
     ]
+  },
+  "volta": {
+    "node": "20.0.0",
+    "yarn": "4.1.1"
   }
 }


### PR DESCRIPTION
Adds [https://volta.sh/](https://volta.sh/) configuration to package.json as an alternative to nvm.

Volta is used by other repositories such as TypeScript to manage the toolchain of package managers.

We could consider changing the onboarding flow for future contributors to simply be:
- install Volta with something akin to `curl https://get.volta.sh | bash`
- now both `node` and `yarn` are installed, and enforced to be the same version across everyone who contributes

This would remove our need to have people go through corepack to install yarn.