### PR TITLE
Allow admins to make dates unavailable using endpoint

### DIFF
--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -26,9 +26,12 @@ export interface paths {
   "/bookings/available-dates": {
     post: operations["GetAvailableDates"];
   };
-  "/admin/bookings/make-date-available": {
+  "/admin/bookings/make-dates-available": {
     /** @description Booking Operations */
     post: operations["MakeDateAvailable"];
+  };
+  "/admin/bookings/make-dates-unavailable": {
+    post: operations["MakeDateUnavailable"];
   };
   "/admin/users": {
     /** @description User Operations */
@@ -180,9 +183,13 @@ export interface components {
       startDate?: components["schemas"]["FirebaseFirestore.Timestamp"];
       endDate?: components["schemas"]["FirebaseFirestore.Timestamp"];
     };
-    CommonResponse: {
+    BookingSlotUpdateResponse: {
       error?: string;
       message?: string;
+      updatedBookingSlots?: {
+          bookingSlotId: string;
+          date: components["schemas"]["FirebaseFirestore.Timestamp"];
+        }[];
     };
     MakeDatesAvailableRequestBody: {
       startDate: components["schemas"]["FirebaseFirestore.Timestamp"];
@@ -349,12 +356,22 @@ export interface operations {
       /** @description Slot made available */
       201: {
         content: {
-          "application/json": {
-            updatedBookingSlots?: {
-                bookingSlotId: string;
-                date: components["schemas"]["FirebaseFirestore.Timestamp"];
-              }[];
-          } & components["schemas"]["CommonResponse"];
+          "application/json": components["schemas"]["BookingSlotUpdateResponse"];
+        };
+      };
+    };
+  };
+  MakeDateUnavailable: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["MakeDatesAvailableRequestBody"];
+      };
+    };
+    responses: {
+      /** @description Slot made unavailable */
+      201: {
+        content: {
+          "application/json": components["schemas"]["BookingSlotUpdateResponse"];
         };
       };
     };

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -176,11 +176,12 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CommonResponse": {
+    "BookingSlotUpdateResponse": {
         "dataType": "refObject",
         "properties": {
             "error": {"dataType":"string"},
             "message": {"dataType":"string"},
+            "updatedBookingSlots": {"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"bookingSlotId":{"dataType":"string","required":true},"date":{"ref":"FirebaseFirestore.Timestamp","required":true}}}},
         },
         "additionalProperties": false,
     },
@@ -459,7 +460,7 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/admin/bookings/make-date-available',
+        app.post('/admin/bookings/make-dates-available',
             authenticateMiddleware([{"jwt":["admin"]}]),
             ...(fetchMiddlewares<RequestHandler>(AdminController)),
             ...(fetchMiddlewares<RequestHandler>(AdminController.prototype.makeDateAvailable)),
@@ -479,6 +480,37 @@ export function RegisterRoutes(app: Router) {
 
               templateService.apiHandler({
                 methodName: 'makeDateAvailable',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 201,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/admin/bookings/make-dates-unavailable',
+            authenticateMiddleware([{"jwt":["admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminController.prototype.makeDateUnavailable)),
+
+            function AdminController_makeDateUnavailable(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    requestBody: {"in":"body","name":"requestBody","required":true,"ref":"MakeDatesAvailableRequestBody"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new AdminController();
+
+              templateService.apiHandler({
+                methodName: 'makeDateUnavailable',
                 controller,
                 response,
                 next,

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -383,13 +383,31 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"CommonResponse": {
+			"BookingSlotUpdateResponse": {
 				"properties": {
 					"error": {
 						"type": "string"
 					},
 					"message": {
 						"type": "string"
+					},
+					"updatedBookingSlots": {
+						"items": {
+							"properties": {
+								"bookingSlotId": {
+									"type": "string"
+								},
+								"date": {
+									"$ref": "#/components/schemas/FirebaseFirestore.Timestamp"
+								}
+							},
+							"required": [
+								"bookingSlotId",
+								"date"
+							],
+							"type": "object"
+						},
+						"type": "array"
 					}
 				},
 				"type": "object",
@@ -756,7 +774,7 @@
 				}
 			}
 		},
-		"/admin/bookings/make-date-available": {
+		"/admin/bookings/make-dates-available": {
 			"post": {
 				"operationId": "MakeDateAvailable",
 				"responses": {
@@ -765,40 +783,48 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"allOf": [
-										{
-											"properties": {
-												"updatedBookingSlots": {
-													"items": {
-														"properties": {
-															"bookingSlotId": {
-																"type": "string"
-															},
-															"date": {
-																"$ref": "#/components/schemas/FirebaseFirestore.Timestamp"
-															}
-														},
-														"required": [
-															"bookingSlotId",
-															"date"
-														],
-														"type": "object"
-													},
-													"type": "array"
-												}
-											},
-											"type": "object"
-										},
-										{
-											"$ref": "#/components/schemas/CommonResponse"
-										}
-									]
+									"$ref": "#/components/schemas/BookingSlotUpdateResponse"
 								}
 							}
 						}
 					}
 				},
 				"description": "Booking Operations",
+				"security": [
+					{
+						"jwt": [
+							"admin"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/MakeDatesAvailableRequestBody"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/admin/bookings/make-dates-unavailable": {
+			"post": {
+				"operationId": "MakeDateUnavailable",
+				"responses": {
+					"201": {
+						"description": "Slot made unavailable",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BookingSlotUpdateResponse"
+								}
+							}
+						}
+					}
+				},
 				"security": [
 					{
 						"jwt": [

--- a/server/src/service-layer/response-models/BookingResponse.ts
+++ b/server/src/service-layer/response-models/BookingResponse.ts
@@ -1,0 +1,6 @@
+import { Timestamp } from "firebase-admin/firestore"
+import { CommonResponse } from "./CommonResponse"
+
+export interface BookingSlotUpdateResponse extends CommonResponse {
+  updatedBookingSlots?: { date: Timestamp; bookingSlotId: string }[]
+}


### PR DESCRIPTION
Mostly a copy-paste job of #349, added extra test to make sure it works for skipped dates:
i.e
```
has booking slot / no booking slot / has booking slot
```
Also refactored the names to be plural instead

Is needed for (is blocking) #390 