### PR TITLE
Allow make available endpoint to take in custom slots

### DIFF
--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -207,8 +207,12 @@ export interface components {
         }[];
     };
     MakeDatesAvailableRequestBody: {
+      /** @description Firestore timestamp, ideally with the time information removed (set to midnight) */
       startDate: components["schemas"]["FirebaseFirestore.Timestamp"];
+      /** @description Firestore timestamp, ideally with the time information removed (set to midnight) */
       endDate: components["schemas"]["FirebaseFirestore.Timestamp"];
+      /** Format: double */
+      slots?: number;
     };
     CreateUserRequestBody: {
       uid: string;

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -214,6 +214,15 @@ export interface components {
       /** Format: double */
       slots?: number;
     };
+    /** @description From T, pick a set of properties whose keys are in the union K */
+    "Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__": {
+      /** @description Firestore timestamp, ideally with the time information removed (set to midnight) */
+      startDate: components["schemas"]["FirebaseFirestore.Timestamp"];
+      /** @description Firestore timestamp, ideally with the time information removed (set to midnight) */
+      endDate: components["schemas"]["FirebaseFirestore.Timestamp"];
+    };
+    /** @description Construct a type with the properties of T except for those in type K. */
+    "Omit_MakeDatesAvailableRequestBody.slots_": components["schemas"]["Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__"];
     CreateUserRequestBody: {
       uid: string;
       user: components["schemas"]["UserAdditionalInfo"];
@@ -393,7 +402,7 @@ export interface operations {
   MakeDateUnavailable: {
     requestBody: {
       content: {
-        "application/json": components["schemas"]["MakeDatesAvailableRequestBody"];
+        "application/json": components["schemas"]["Omit_MakeDatesAvailableRequestBody.slots_"];
       };
     };
     responses: {

--- a/server/src/business-layer/utils/BookingConstants.ts
+++ b/server/src/business-layer/utils/BookingConstants.ts
@@ -1,7 +1,7 @@
 /**
  * The default max amount of spots a booking should have. Used when making booking available
  */
-export const DEFAULT_BOOKING_MAX_SLOTS = 30 as const
+export const DEFAULT_BOOKING_MAX_SLOTS = 32 as const
 
 /**
  * A constant that the `max_bookings` field should be set to for a `booking_slot` to indicate its unavailable

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -201,6 +201,7 @@ const models: TsoaRoute.Models = {
         "properties": {
             "startDate": {"ref":"FirebaseFirestore.Timestamp","required":true},
             "endDate": {"ref":"FirebaseFirestore.Timestamp","required":true},
+            "slots": {"dataType":"double","validators":{"maximum":{"errorMsg":"You have exceeded the maximum slots for bookings","value":42}}},
         },
         "additionalProperties": false,
     },

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -201,9 +201,19 @@ const models: TsoaRoute.Models = {
         "properties": {
             "startDate": {"ref":"FirebaseFirestore.Timestamp","required":true},
             "endDate": {"ref":"FirebaseFirestore.Timestamp","required":true},
-            "slots": {"dataType":"double","validators":{"maximum":{"errorMsg":"You have exceeded the maximum slots for bookings","value":42}}},
+            "slots": {"dataType":"double","validators":{"maximum":{"errorMsg":"You have exceeded the maximum slots for bookings","value":32},"minimum":{"errorMsg":"must be positive","value":0}}},
         },
         "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"startDate":{"ref":"FirebaseFirestore.Timestamp","required":true},"endDate":{"ref":"FirebaseFirestore.Timestamp","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Omit_MakeDatesAvailableRequestBody.slots_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "CreateUserRequestBody": {
@@ -538,7 +548,7 @@ export function RegisterRoutes(app: Router) {
 
             function AdminController_makeDateUnavailable(request: ExRequest, response: ExResponse, next: any) {
             const args: Record<string, TsoaRoute.ParameterSchema> = {
-                    requestBody: {"in":"body","name":"requestBody","required":true,"ref":"MakeDatesAvailableRequestBody"},
+                    requestBody: {"in":"body","name":"requestBody","required":true,"ref":"Omit_MakeDatesAvailableRequestBody.slots_"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -470,7 +470,8 @@
 					"slots": {
 						"type": "number",
 						"format": "double",
-						"maximum": 42
+						"maximum": 32,
+						"minimum": 0
 					}
 				},
 				"required": [
@@ -479,6 +480,28 @@
 				],
 				"type": "object",
 				"additionalProperties": false
+			},
+			"Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__": {
+				"properties": {
+					"startDate": {
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
+						"description": "Firestore timestamp, ideally with the time information removed (set to midnight)"
+					},
+					"endDate": {
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
+						"description": "Firestore timestamp, ideally with the time information removed (set to midnight)"
+					}
+				},
+				"required": [
+					"startDate",
+					"endDate"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_MakeDatesAvailableRequestBody.slots_": {
+				"$ref": "#/components/schemas/Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__",
+				"description": "Construct a type with the properties of T except for those in type K."
 			},
 			"CreateUserRequestBody": {
 				"properties": {
@@ -908,7 +931,7 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/MakeDatesAvailableRequestBody"
+								"$ref": "#/components/schemas/Omit_MakeDatesAvailableRequestBody.slots_"
 							}
 						}
 					}

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -460,10 +460,17 @@
 			"MakeDatesAvailableRequestBody": {
 				"properties": {
 					"startDate": {
-						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp"
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
+						"description": "Firestore timestamp, ideally with the time information removed (set to midnight)"
 					},
 					"endDate": {
-						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp"
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
+						"description": "Firestore timestamp, ideally with the time information removed (set to midnight)"
+					},
+					"slots": {
+						"type": "number",
+						"format": "double",
+						"maximum": 42
 					}
 				},
 				"required": [

--- a/server/src/middleware/routes.test.ts
+++ b/server/src/middleware/routes.test.ts
@@ -25,6 +25,7 @@ import BookingSlotService from "data-layer/services/BookingSlotsService"
 import { dateToFirestoreTimeStamp } from "data-layer/adapters/DateUtils"
 import BookingDataService from "data-layer/services/BookingDataService"
 import { Timestamp } from "firebase-admin/firestore"
+import { DEFAULT_BOOKING_MAX_SLOTS } from "business-layer/utils/BookingConstants"
 
 const request = supertest(_app)
 
@@ -642,6 +643,10 @@ describe("Endpoints", () => {
       )
 
       expect(dates).toHaveLength(6)
+
+      dates.forEach((date) => {
+        expect(date.max_bookings).toEqual(DEFAULT_BOOKING_MAX_SLOTS)
+      })
     })
 
     it("Should create booking slots specified within the date range, using the specified slots", async () => {

--- a/server/src/middleware/routes.test.ts
+++ b/server/src/middleware/routes.test.ts
@@ -649,7 +649,7 @@ describe("Endpoints", () => {
       })
     })
 
-    it("Should create booking slots specified within the date range, using the specified slots", async () => {
+    it("Should create booking slots specified within the date range, using the specified slots - while also overwriting old availabilities", async () => {
       const startDate = dateToFirestoreTimeStamp(new Date("10/09/2001"))
       const endDate = dateToFirestoreTimeStamp(new Date("10/14/2001"))
       let res = await request
@@ -663,7 +663,32 @@ describe("Endpoints", () => {
 
       expect(res.status).toEqual(400) // exceed maximum
 
+      res = await request
+        .post("/admin/bookings/make-dates-available")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({
+          startDate,
+          endDate
+        })
+
+      expect(res.status).toEqual(201)
+      expect(res.body.updatedBookingSlots).toHaveLength(6)
+      expect(res.body.updatedBookingSlots[0].date).toEqual(startDate)
+      expect(res.body.updatedBookingSlots[5].date).toEqual(endDate)
+
+      let dates = await bookingSlotService.getBookingSlotsBetweenDateRange(
+        startDate,
+        endDate
+      )
+
+      expect(dates).toHaveLength(6)
+
+      dates.forEach((date) => {
+        expect(date.max_bookings).toEqual(DEFAULT_BOOKING_MAX_SLOTS)
+      })
+
       const CUSTOM_SLOTS = 11 as const
+
       res = await request
         .post("/admin/bookings/make-dates-available")
         .set("Authorization", `Bearer ${adminToken}`)
@@ -676,7 +701,7 @@ describe("Endpoints", () => {
       expect(res.body.updatedBookingSlots[0].date).toEqual(startDate)
       expect(res.body.updatedBookingSlots[5].date).toEqual(endDate)
 
-      const dates = await bookingSlotService.getBookingSlotsBetweenDateRange(
+      dates = await bookingSlotService.getBookingSlotsBetweenDateRange(
         startDate,
         endDate
       )

--- a/server/src/middleware/routes.test.ts
+++ b/server/src/middleware/routes.test.ts
@@ -644,6 +644,45 @@ describe("Endpoints", () => {
       expect(dates).toHaveLength(6)
     })
 
+    it("Should create booking slots specified within the date range, using the specified slots", async () => {
+      const startDate = dateToFirestoreTimeStamp(new Date("10/09/2001"))
+      const endDate = dateToFirestoreTimeStamp(new Date("10/14/2001"))
+      let res = await request
+        .post("/admin/bookings/make-dates-available")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({
+          startDate,
+          endDate,
+          slots: 69
+        })
+
+      expect(res.status).toEqual(400) // exceed maximum
+
+      const CUSTOM_SLOTS = 11 as const
+      res = await request
+        .post("/admin/bookings/make-dates-available")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({
+          startDate,
+          endDate,
+          slots: CUSTOM_SLOTS
+        })
+      expect(res.body.updatedBookingSlots).toHaveLength(6)
+      expect(res.body.updatedBookingSlots[0].date).toEqual(startDate)
+      expect(res.body.updatedBookingSlots[5].date).toEqual(endDate)
+
+      const dates = await bookingSlotService.getBookingSlotsBetweenDateRange(
+        startDate,
+        endDate
+      )
+
+      expect(dates).toHaveLength(6)
+
+      dates.forEach((date) => {
+        expect(date.max_bookings).toEqual(CUSTOM_SLOTS)
+      })
+    })
+
     it("Should not do anything if the start/end dates are the wrong way around", async () => {
       const startDate = dateToFirestoreTimeStamp(new Date("10/14/2001"))
       const endDate = dateToFirestoreTimeStamp(new Date("10/09/2001"))

--- a/server/src/service-layer/controllers/AdminController.ts
+++ b/server/src/service-layer/controllers/AdminController.ts
@@ -65,11 +65,9 @@ export class AdminController extends Controller {
         }
 
         // Was unavailable
-        if (bookingSlotForDate.max_bookings <= EMPTY_BOOKING_SLOTS) {
-          await bookingSlotService.updateBookingSlot(bookingSlotForDate.id, {
-            max_bookings: slots || DEFAULT_BOOKING_MAX_SLOTS
-          })
-        }
+        await bookingSlotService.updateBookingSlot(bookingSlotForDate.id, {
+          max_bookings: slots || DEFAULT_BOOKING_MAX_SLOTS
+        })
 
         return { bookingSlotId: bookingSlotForDate.id, date: dateTimestamp }
       } catch (e) {

--- a/server/src/service-layer/controllers/AdminController.ts
+++ b/server/src/service-layer/controllers/AdminController.ts
@@ -42,7 +42,7 @@ export class AdminController extends Controller {
   public async makeDateAvailable(
     @Body() requestBody: MakeDatesAvailableRequestBody
   ): Promise<BookingSlotUpdateResponse> {
-    const { startDate, endDate } = requestBody
+    const { startDate, endDate, slots } = requestBody
     const bookingSlotService = new BookingSlotService()
 
     const dates = datesToDateRange(
@@ -59,7 +59,7 @@ export class AdminController extends Controller {
         if (!bookingSlotForDate) {
           const bookingSlot = await bookingSlotService.createBookingSlot({
             date: dateTimestamp,
-            max_bookings: DEFAULT_BOOKING_MAX_SLOTS
+            max_bookings: slots || DEFAULT_BOOKING_MAX_SLOTS
           })
           return { bookingSlotId: bookingSlot.id, date: dateTimestamp }
         }
@@ -67,7 +67,7 @@ export class AdminController extends Controller {
         // Was unavailable
         if (bookingSlotForDate.max_bookings <= EMPTY_BOOKING_SLOTS) {
           await bookingSlotService.updateBookingSlot(bookingSlotForDate.id, {
-            max_bookings: DEFAULT_BOOKING_MAX_SLOTS
+            max_bookings: slots || DEFAULT_BOOKING_MAX_SLOTS
           })
         }
 
@@ -94,7 +94,7 @@ export class AdminController extends Controller {
   @SuccessResponse("201", "Slot made unavailable")
   @Post("/bookings/make-dates-unavailable")
   public async makeDateUnavailable(
-    @Body() requestBody: MakeDatesAvailableRequestBody
+    @Body() requestBody: Omit<MakeDatesAvailableRequestBody, "slots">
   ): Promise<BookingSlotUpdateResponse> {
     const { startDate, endDate } = requestBody
     const bookingSlotService = new BookingSlotService()

--- a/server/src/service-layer/request-models/AdminRequests.ts
+++ b/server/src/service-layer/request-models/AdminRequests.ts
@@ -1,6 +1,20 @@
 import { Timestamp } from "firebase-admin/firestore"
 
 export interface MakeDatesAvailableRequestBody {
+  /**
+   * Firestore timestamp, ideally with the time information removed (set to midnight)
+   */
   startDate: Timestamp
+
+  /**
+   * Firestore timestamp, ideally with the time information removed (set to midnight)
+   */
   endDate: Timestamp
+
+  /**
+   * @isNumber Please enter a number
+   * @maximum 32 You have exceeded the maximum slots for bookings
+   * @minimum 0 must be positive
+   */
+  slots?: number
 }


### PR DESCRIPTION
# Custom slot qty for `/admin/bookings/make-dates-available`

There is the use case for when admins want to make a date available with less than the default (32) spots (such as pre booked dates). To solve this an *optional* parameter has been added to the request body. New tests have been added to make sure it:

- Overwrites old values
- Still applies the default in case of undefined

