### PR TITLE
400 frontend make all users endpoint return correct fields + paginate

### DIFF
--- a/client/src/components/composite/Admin/AdminMemberView/AdminMemberView.tsx
+++ b/client/src/components/composite/Admin/AdminMemberView/AdminMemberView.tsx
@@ -5,7 +5,7 @@ import {
   TABLE_ROW_IDENTIFIER_KEY,
   TableRowOperation
 } from "components/generic/ReusableTable/TableUtils"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 export type MemberColumnFormat = {
   /**
@@ -39,6 +39,16 @@ interface IAdminMemberView {
    * ```
    */
   rowOperations?: TableRowOperation[]
+
+  /**
+   * used to fetch the data once the last page of the table has been reached
+   */
+  fetchNextPage?: () => void
+
+  /**
+   * If there is more pages to fetch
+   */
+  hasNextPage?: boolean
 }
 
 /**
@@ -54,8 +64,14 @@ const defaultData = {
 
 const ADMIN_MEMBER_VIEW_MIN_SEARCH_QUERY_LENGTH = 2 as const
 
-export const AdminMemberView = ({ data, rowOperations }: IAdminMemberView) => {
+export const AdminMemberView = ({
+  data,
+  rowOperations,
+  fetchNextPage,
+  hasNextPage
+}: IAdminMemberView) => {
   const [currentSearchQuery, setCurrentSearchQuery] = useState<string>("")
+  const [isLastPage, setIsLastPage] = useState<boolean>(false)
   const dataFilter = (oldData: MemberColumnFormat[]) =>
     currentSearchQuery.length > ADMIN_MEMBER_VIEW_MIN_SEARCH_QUERY_LENGTH
       ? oldData.filter(
@@ -64,6 +80,13 @@ export const AdminMemberView = ({ data, rowOperations }: IAdminMemberView) => {
             item.Name?.toLowerCase().includes(currentSearchQuery)
         )
       : oldData
+
+  useEffect(() => {
+    if (isLastPage && hasNextPage) {
+      fetchNextPage?.()
+    }
+  }, [isLastPage, hasNextPage])
+
   const onSeachQueryChangedHandler = (newQuery: string) => {
     setCurrentSearchQuery(newQuery)
   }
@@ -80,6 +103,11 @@ export const AdminMemberView = ({ data, rowOperations }: IAdminMemberView) => {
         data={(data && dataFilter(data)) || [defaultData]}
         operationType="multiple-operations"
         rowOperations={rowOperations}
+        // Make sure that this is smaller than the amount we fetch in the `AdminService` for better UX
+        showPerPage={15}
+        onPageChange={(last) => {
+          setIsLastPage(last)
+        }}
       />
     </>
   )

--- a/client/src/components/composite/Admin/AdminMemberView/AdminMemberView.tsx
+++ b/client/src/components/composite/Admin/AdminMemberView/AdminMemberView.tsx
@@ -44,11 +44,6 @@ interface IAdminMemberView {
    * used to fetch the data once the last page of the table has been reached
    */
   fetchNextPage?: () => void
-
-  /**
-   * If there is more pages to fetch
-   */
-  hasNextPage?: boolean
 }
 
 /**
@@ -67,13 +62,14 @@ const ADMIN_MEMBER_VIEW_MIN_SEARCH_QUERY_LENGTH = 2 as const
 export const AdminMemberView = ({
   data,
   rowOperations,
-  fetchNextPage,
-  hasNextPage
+  fetchNextPage
 }: IAdminMemberView) => {
   const [currentSearchQuery, setCurrentSearchQuery] = useState<string>("")
   const [isLastPage, setIsLastPage] = useState<boolean>(false)
-  const dataFilter = (oldData: MemberColumnFormat[]) =>
+  const isValidSearchQuery =
     currentSearchQuery.length > ADMIN_MEMBER_VIEW_MIN_SEARCH_QUERY_LENGTH
+  const dataFilter = (oldData: MemberColumnFormat[]) =>
+    isValidSearchQuery
       ? oldData.filter(
           (item) =>
             item.Email?.toLowerCase().includes(currentSearchQuery) ||
@@ -82,10 +78,10 @@ export const AdminMemberView = ({
       : oldData
 
   useEffect(() => {
-    if (isLastPage && hasNextPage) {
+    if (isLastPage || isValidSearchQuery) {
       fetchNextPage?.()
     }
-  }, [isLastPage, hasNextPage])
+  }, [isLastPage, fetchNextPage, isValidSearchQuery])
 
   const onSeachQueryChangedHandler = (newQuery: string) => {
     setCurrentSearchQuery(newQuery)

--- a/client/src/components/composite/Admin/AdminMemberView/ProtectedAdminMemberView.tsx
+++ b/client/src/components/composite/Admin/AdminMemberView/ProtectedAdminMemberView.tsx
@@ -84,9 +84,8 @@ const WrappedAdminMemberView = () => {
   return (
     <AdminMemberView
       fetchNextPage={() => {
-        !isFetchingNextPage && fetchNextPage()
+        !isFetchingNextPage && hasNextPage && fetchNextPage()
       }}
-      hasNextPage={hasNextPage}
       rowOperations={rowOperations}
       data={transformedDataList}
     />

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -233,10 +233,19 @@ export interface components {
     AllUsersResponse: {
       error?: string;
       message?: string;
-      data: components["schemas"]["UserAdditionalInfo"][] & {
+      /**
+       * @description Needed for firestore operations which do not support offset
+       * based pagination
+       */
+      nextCursor?: string;
+      data?: components["schemas"]["UserAdditionalInfo"][] & {
+          /** @description What type of account the user has */
           membership: components["schemas"]["UserAccountTypes"];
+          /** @description The email the user uses to log in */
           email: string;
+          /** @description Formatted UTC date string of when the account was created */
           dateJoined: string;
+          /** @description Firebase identifier of the user *data* based on the firestore document */
           uid: string;
         }[];
     };
@@ -460,6 +469,12 @@ export interface operations {
   };
   /** @description User Operations */
   GetAllUsers: {
+    parameters: {
+      query?: {
+        cursor?: string;
+        toFetch?: number;
+      };
+    };
     responses: {
       /** @description Users found */
       200: {

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -230,6 +230,16 @@ export interface components {
     };
     /** @enum {string} */
     UserAccountTypes: "admin" | "member" | "guest";
+    CombinedUserData: components["schemas"]["UserAdditionalInfo"] & {
+      /** @description What type of account the user has */
+      membership: components["schemas"]["UserAccountTypes"];
+      /** @description The email the user uses to log in */
+      email: string;
+      /** @description Formatted UTC date string of when the account was created */
+      dateJoined?: string;
+      /** @description Firebase identifier of the user *data* based on the firestore document */
+      uid: string;
+    };
     AllUsersResponse: {
       error?: string;
       message?: string;
@@ -238,16 +248,7 @@ export interface components {
        * based pagination
        */
       nextCursor?: string;
-      data?: components["schemas"]["UserAdditionalInfo"][] & {
-          /** @description What type of account the user has */
-          membership: components["schemas"]["UserAccountTypes"];
-          /** @description The email the user uses to log in */
-          email: string;
-          /** @description Formatted UTC date string of when the account was created */
-          dateJoined: string;
-          /** @description Firebase identifier of the user *data* based on the firestore document */
-          uid: string;
-        }[];
+      data?: components["schemas"]["CombinedUserData"][];
     };
     CreateUserRequestBody: {
       uid: string;

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -246,6 +246,8 @@ export interface components {
       /**
        * @description Needed for firestore operations which do not support offset
        * based pagination
+       *
+       * **Will be undefined in case of last page**
        */
       nextCursor?: string;
       data?: components["schemas"]["CombinedUserData"][];

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -82,28 +82,6 @@ export interface components {
        */
       nanoseconds: number;
     };
-    UserAdditionalInfo: {
-      date_of_birth: components["schemas"]["FirebaseFirestore.Timestamp"];
-      does_snowboarding: boolean;
-      does_racing: boolean;
-      does_ski: boolean;
-      gender: string;
-      emergency_contact?: string;
-      first_name: string;
-      last_name: string;
-      dietary_requirements: string;
-      faculty?: string;
-      university?: string;
-      student_id?: string;
-      returning: boolean;
-      university_year: string;
-      /** @description For identification DO NOT RETURN to users in exposed endpoints */
-      stripe_id?: string;
-    };
-    FirebaseProperties: {
-      uid: string;
-    };
-    UserResponse: components["schemas"]["UserAdditionalInfo"] & components["schemas"]["FirebaseProperties"];
     /** @description From T, pick a set of properties whose keys are in the union K */
     "Pick_Partial_UserAdditionalInfo_.Exclude_keyofPartial_UserAdditionalInfo_.stripe_id__": {
       date_of_birth?: components["schemas"]["FirebaseFirestore.Timestamp"];
@@ -232,6 +210,36 @@ export interface components {
     };
     /** @description Construct a type with the properties of T except for those in type K. */
     "Omit_MakeDatesAvailableRequestBody.slots_": components["schemas"]["Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__"];
+    UserAdditionalInfo: {
+      date_of_birth: components["schemas"]["FirebaseFirestore.Timestamp"];
+      does_snowboarding: boolean;
+      does_racing: boolean;
+      does_ski: boolean;
+      gender: string;
+      emergency_contact?: string;
+      first_name: string;
+      last_name: string;
+      dietary_requirements: string;
+      faculty?: string;
+      university?: string;
+      student_id?: string;
+      returning: boolean;
+      university_year: string;
+      /** @description For identification DO NOT RETURN to users in exposed endpoints */
+      stripe_id?: string;
+    };
+    /** @enum {string} */
+    UserAccountTypes: "admin" | "member" | "guest";
+    AllUsersResponse: {
+      error?: string;
+      message?: string;
+      data: components["schemas"]["UserAdditionalInfo"][] & {
+          membership: components["schemas"]["UserAccountTypes"];
+          email: string;
+          dateJoined: string;
+          uid: string;
+        }[];
+    };
     CreateUserRequestBody: {
       uid: string;
       user: components["schemas"]["UserAdditionalInfo"];
@@ -290,7 +298,24 @@ export interface operations {
       /** @description Fetched self data */
       200: {
         content: {
-          "application/json": components["schemas"]["UserResponse"];
+          "application/json": {
+            stripe_id?: string;
+            university_year: string;
+            returning: boolean;
+            student_id?: string;
+            university?: string;
+            faculty?: string;
+            dietary_requirements: string;
+            last_name: string;
+            first_name: string;
+            emergency_contact?: string;
+            gender: string;
+            does_ski: boolean;
+            does_racing: boolean;
+            does_snowboarding: boolean;
+            date_of_birth: components["schemas"]["FirebaseFirestore.Timestamp"];
+            uid: string;
+          };
         };
       };
     };
@@ -439,7 +464,7 @@ export interface operations {
       /** @description Users found */
       200: {
         content: {
-          "application/json": components["schemas"]["UserResponse"][];
+          "application/json": components["schemas"]["AllUsersResponse"];
         };
       };
     };

--- a/client/src/services/Admin/AdminQueries.ts
+++ b/client/src/services/Admin/AdminQueries.ts
@@ -1,10 +1,12 @@
-import { useQuery } from "@tanstack/react-query"
+import { useInfiniteQuery } from "@tanstack/react-query"
 import AdminService from "./AdminService"
 
 export function useUsersQuery() {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ["allUsers"],
-    queryFn: () => AdminService.getUsers(),
-    retry: 3
+    queryFn: AdminService.getUsers,
+    retry: 1,
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor
   })
 }

--- a/client/src/services/Admin/AdminService.ts
+++ b/client/src/services/Admin/AdminService.ts
@@ -1,6 +1,7 @@
 import { Timestamp } from "firebase/firestore"
 import { UserAdditionalInfo } from "models/User"
 import fetchClient from "services/OpenApiFetchClient"
+import { MEMBER_TABLE_MAX_DATA } from "utils/Constants"
 
 export type EditUsersBody = {
   uid: string
@@ -8,8 +9,21 @@ export type EditUsersBody = {
 }[]
 
 const AdminService = {
-  getUsers: async function () {
-    const { data } = await fetchClient.GET("/admin/users", {})
+  getUsers: async function ({
+    limit = MEMBER_TABLE_MAX_DATA,
+    pageParam
+  }: {
+    pageParam?: string
+    limit?: number
+  }) {
+    const { data } = await fetchClient.GET("/admin/users", {
+      params: {
+        query: {
+          cursor: pageParam,
+          toFetch: limit
+        }
+      }
+    })
     if (!data) throw new Error("Failed to fetch all users")
     return data
   },

--- a/client/src/utils/Constants.ts
+++ b/client/src/utils/Constants.ts
@@ -1,2 +1,3 @@
 export const MS_IN_SECOND = 1000 as const
 export const DEFAULT_BOOKING_AVAILABILITY = 32 as const
+export const MEMBER_TABLE_MAX_DATA = 15

--- a/client/src/utils/Constants.ts
+++ b/client/src/utils/Constants.ts
@@ -1,3 +1,3 @@
 export const MS_IN_SECOND = 1000 as const
 export const DEFAULT_BOOKING_AVAILABILITY = 32 as const
-export const MEMBER_TABLE_MAX_DATA = 15
+export const MEMBER_TABLE_MAX_DATA = 100

--- a/server/src/business-layer/services/AuthService.ts
+++ b/server/src/business-layer/services/AuthService.ts
@@ -2,7 +2,24 @@ import { UserRecord } from "firebase-admin/auth"
 import { auth } from "business-layer/security/Firebase"
 import { AuthServiceClaims } from "business-layer/utils/AuthServiceClaims"
 
+type UidArray = {
+  uid: string
+}[]
+
 export default class AuthService {
+  /**
+   *
+   */
+  public async bulkRetrieveUsersByUids(uids: UidArray) {
+    try {
+      const { users } = await auth.getUsers(uids)
+      return users
+    } catch (e) {
+      console.error(`Failed to bulk retrieve the uids from Auth`, e)
+      return undefined
+    }
+  }
+
   /**
    * Deletes a user account from the Firebase Authentication Service.
    * @param uid

--- a/server/src/business-layer/services/AuthService.ts
+++ b/server/src/business-layer/services/AuthService.ts
@@ -8,7 +8,13 @@ type UidArray = {
 
 export default class AuthService {
   /**
+   * Fetches up to **100** users based on an array of uid identifiers
    *
+   * @throws **Passing more than 100 will result in a FirebaseAuthError**
+   *
+   * @param uids an array of objects containing the key `uid`,
+   * which has the value of the firebase user uid
+   * @example // [{uid:"uid1", uid:"uid2"}]
    */
   public async bulkRetrieveUsersByUids(uids: UidArray) {
     try {

--- a/server/src/business-layer/utils/AuthServiceClaims.ts
+++ b/server/src/business-layer/utils/AuthServiceClaims.ts
@@ -2,3 +2,9 @@ export const AuthServiceClaims = {
   MEMBER: "member",
   ADMIN: "admin"
 } as const
+
+export enum UserAccountTypes {
+  ADMIN = "admin",
+  MEMBER = "member",
+  GUEST = "guest"
+}

--- a/server/src/data-layer/services/UserDataService.test.ts
+++ b/server/src/data-layer/services/UserDataService.test.ts
@@ -61,7 +61,7 @@ describe("UserService integration tests", () => {
     await userService.createUserData(TEST_UID_1, userInfoMock)
     await userService.createUserData("testUser2", userInfoMock)
 
-    const users = await userService.getAllUserData()
+    const { users } = await userService.getAllUserData()
 
     expect(users.length).toEqual(2)
   })

--- a/server/src/data-layer/services/UserDataService.test.ts
+++ b/server/src/data-layer/services/UserDataService.test.ts
@@ -57,6 +57,12 @@ describe("UserService integration tests", () => {
     expect(user).toEqual(undefined)
   })
 
+  it("should be able to get a doc snapshot", async () => {
+    await userService.createUserData(TEST_UID_1, userInfoMock)
+    const snapshot = await userService.getUserDocumentSnapshot(TEST_UID_1)
+    expect(snapshot.id).toEqual(TEST_UID_1)
+  })
+
   it("should get all users", async () => {
     await userService.createUserData(TEST_UID_1, userInfoMock)
     await userService.createUserData("testUser2", userInfoMock)
@@ -64,6 +70,24 @@ describe("UserService integration tests", () => {
     const { users } = await userService.getAllUserData()
 
     expect(users.length).toEqual(2)
+  })
+
+  it("should be able to paginate through users", async () => {
+    await userService.createUserData(TEST_UID_1, userInfoMock)
+    await userService.createUserData("testUser2", userInfoMock)
+
+    const { users } = await userService.getAllUserData(1)
+
+    expect(users).toHaveLength(1)
+
+    const { users: paginatedUsers } = await userService.getAllUserData(
+      undefined,
+      await userService.getUserDocumentSnapshot(users[0].uid)
+    )
+
+    expect(paginatedUsers).toHaveLength(1)
+    // Check exclusive
+    expect(paginatedUsers[0].uid).not.toEqual(users[0].uid)
   })
 
   it("should filter users by first name", async () => {

--- a/server/src/data-layer/services/UserDataService.ts
+++ b/server/src/data-layer/services/UserDataService.ts
@@ -13,13 +13,33 @@ export default class UserDataService {
     await FirestoreCollections.users.doc(uid).set(additionalInfo)
   }
 
-  // Read
-  public async getAllUserData() {
-    const res = await FirestoreCollections.users.get()
+  /**
+   * @param [limit] how many users to fetch at once
+   * @param [startAfter] the cursor to start searching for users at
+   * @returns list of users, sorted by first name *and* the next cursor
+   */
+  public async getAllUserData(
+    limit: number = 100,
+    startAfter?: FirebaseFirestore.DocumentSnapshot<
+      UserAdditionalInfo,
+      FirebaseFirestore.DocumentData
+    >
+  ) {
+    // is ordered by id by default
+    const res = await FirestoreCollections.users
+      .orderBy("first_name")
+      .startAfter(startAfter || 0)
+      .limit(limit)
+      .get()
+
     const users = res.docs.map((user) => {
       return { ...user.data(), uid: user.id }
     })
-    return users
+    return { users, nextCursor: res.docs[res.docs.length - 1]?.id || undefined }
+  }
+
+  public async getUserDocumentSnapshot(uid: string) {
+    return await FirestoreCollections.users.doc(uid).get()
   }
 
   public async getUserData(uid: string) {

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -33,41 +33,6 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UserAdditionalInfo": {
-        "dataType": "refObject",
-        "properties": {
-            "date_of_birth": {"ref":"FirebaseFirestore.Timestamp","required":true},
-            "does_snowboarding": {"dataType":"boolean","required":true},
-            "does_racing": {"dataType":"boolean","required":true},
-            "does_ski": {"dataType":"boolean","required":true},
-            "gender": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please enter your pronouns"}}},
-            "emergency_contact": {"dataType":"string","validators":{"isString":{"errorMsg":"Please enter a name"}}},
-            "first_name": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please enter your First Name"}}},
-            "last_name": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please enter your Second Name"}}},
-            "dietary_requirements": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please write your dietary requirements"}}},
-            "faculty": {"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your faculty"}}},
-            "university": {"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your university"}}},
-            "student_id": {"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your student ID"}}},
-            "returning": {"dataType":"boolean","required":true},
-            "university_year": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please enter your year of study"}}},
-            "stripe_id": {"dataType":"string"},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FirebaseProperties": {
-        "dataType": "refObject",
-        "properties": {
-            "uid": {"dataType":"string","required":true},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UserResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"UserAdditionalInfo"},{"ref":"FirebaseProperties"}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Pick_Partial_UserAdditionalInfo_.Exclude_keyofPartial_UserAdditionalInfo_.stripe_id__": {
         "dataType": "refAlias",
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"date_of_birth":{"ref":"FirebaseFirestore.Timestamp"},"does_snowboarding":{"dataType":"boolean"},"does_racing":{"dataType":"boolean"},"does_ski":{"dataType":"boolean"},"gender":{"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your pronouns"}}},"emergency_contact":{"dataType":"string","validators":{"isString":{"errorMsg":"Please enter a name"}}},"first_name":{"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your First Name"}}},"last_name":{"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your Second Name"}}},"dietary_requirements":{"dataType":"string","validators":{"isString":{"errorMsg":"Please write your dietary requirements"}}},"faculty":{"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your faculty"}}},"university":{"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your university"}}},"student_id":{"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your student ID"}}},"returning":{"dataType":"boolean"},"university_year":{"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your year of study"}}}},"validators":{}},
@@ -224,6 +189,43 @@ const models: TsoaRoute.Models = {
     "Omit_MakeDatesAvailableRequestBody.slots_": {
         "dataType": "refAlias",
         "type": {"ref":"Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UserAdditionalInfo": {
+        "dataType": "refObject",
+        "properties": {
+            "date_of_birth": {"ref":"FirebaseFirestore.Timestamp","required":true},
+            "does_snowboarding": {"dataType":"boolean","required":true},
+            "does_racing": {"dataType":"boolean","required":true},
+            "does_ski": {"dataType":"boolean","required":true},
+            "gender": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please enter your pronouns"}}},
+            "emergency_contact": {"dataType":"string","validators":{"isString":{"errorMsg":"Please enter a name"}}},
+            "first_name": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please enter your First Name"}}},
+            "last_name": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please enter your Second Name"}}},
+            "dietary_requirements": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please write your dietary requirements"}}},
+            "faculty": {"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your faculty"}}},
+            "university": {"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your university"}}},
+            "student_id": {"dataType":"string","validators":{"isString":{"errorMsg":"Please enter your student ID"}}},
+            "returning": {"dataType":"boolean","required":true},
+            "university_year": {"dataType":"string","required":true,"validators":{"isString":{"errorMsg":"Please enter your year of study"}}},
+            "stripe_id": {"dataType":"string"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UserAccountTypes": {
+        "dataType": "refEnum",
+        "enums": ["admin","member","guest"],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AllUsersResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "error": {"dataType":"string"},
+            "message": {"dataType":"string"},
+            "data": {"dataType":"intersection","subSchemas":[{"dataType":"array","array":{"dataType":"refObject","ref":"UserAdditionalInfo"}},{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"membership":{"ref":"UserAccountTypes","required":true},"email":{"dataType":"string","required":true},"dateJoined":{"dataType":"string","required":true},"uid":{"dataType":"string","required":true}}}}],"required":true},
+        },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "CreateUserRequestBody": {

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -223,7 +223,8 @@ const models: TsoaRoute.Models = {
         "properties": {
             "error": {"dataType":"string"},
             "message": {"dataType":"string"},
-            "data": {"dataType":"intersection","subSchemas":[{"dataType":"array","array":{"dataType":"refObject","ref":"UserAdditionalInfo"}},{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"membership":{"ref":"UserAccountTypes","required":true},"email":{"dataType":"string","required":true},"dateJoined":{"dataType":"string","required":true},"uid":{"dataType":"string","required":true}}}}],"required":true},
+            "nextCursor": {"dataType":"string"},
+            "data": {"dataType":"intersection","subSchemas":[{"dataType":"array","array":{"dataType":"refObject","ref":"UserAdditionalInfo"}},{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"membership":{"ref":"UserAccountTypes","required":true},"email":{"dataType":"string","required":true},"dateJoined":{"dataType":"string","required":true},"uid":{"dataType":"string","required":true}}}}]},
         },
         "additionalProperties": false,
     },
@@ -622,6 +623,8 @@ export function RegisterRoutes(app: Router) {
 
             function AdminController_getAllUsers(request: ExRequest, response: ExResponse, next: any) {
             const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    cursor: {"in":"query","name":"cursor","dataType":"string"},
+                    toFetch: {"in":"query","name":"toFetch","dataType":"double"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -218,13 +218,18 @@ const models: TsoaRoute.Models = {
         "enums": ["admin","member","guest"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "CombinedUserData": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"UserAdditionalInfo"},{"dataType":"nestedObjectLiteral","nestedProperties":{"membership":{"ref":"UserAccountTypes","required":true},"email":{"dataType":"string","required":true},"dateJoined":{"dataType":"string"},"uid":{"dataType":"string","required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "AllUsersResponse": {
         "dataType": "refObject",
         "properties": {
             "error": {"dataType":"string"},
             "message": {"dataType":"string"},
             "nextCursor": {"dataType":"string"},
-            "data": {"dataType":"intersection","subSchemas":[{"dataType":"array","array":{"dataType":"refObject","ref":"UserAdditionalInfo"}},{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"membership":{"ref":"UserAccountTypes","required":true},"email":{"dataType":"string","required":true},"dateJoined":{"dataType":"string","required":true},"uid":{"dataType":"string","required":true}}}}]},
+            "data": {"dataType":"array","array":{"dataType":"refAlias","ref":"CombinedUserData"}},
         },
         "additionalProperties": false,
     },

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -553,7 +553,7 @@
 					},
 					"nextCursor": {
 						"type": "string",
-						"description": "Needed for firestore operations which do not support offset\r\nbased pagination"
+						"description": "Needed for firestore operations which do not support offset\r\nbased pagination\r\n\r\n**Will be undefined in case of last page**"
 					},
 					"data": {
 						"items": {

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -553,7 +553,7 @@
 					},
 					"nextCursor": {
 						"type": "string",
-						"description": "Needed for firestore operations which do not support offset\r\nbased pagination\r\n\r\n**Will be undefined in case of last page**"
+						"description": "Needed for firestore operations which do not support offset\nbased pagination\n\n**Will be undefined in case of last page**"
 					},
 					"data": {
 						"items": {

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -518,6 +518,10 @@
 					"message": {
 						"type": "string"
 					},
+					"nextCursor": {
+						"type": "string",
+						"description": "Needed for firestore operations which do not support offset\r\nbased pagination"
+					},
 					"data": {
 						"allOf": [
 							{
@@ -530,16 +534,20 @@
 								"items": {
 									"properties": {
 										"membership": {
-											"$ref": "#/components/schemas/UserAccountTypes"
+											"$ref": "#/components/schemas/UserAccountTypes",
+											"description": "What type of account the user has"
 										},
 										"email": {
-											"type": "string"
+											"type": "string",
+											"description": "The email the user uses to log in"
 										},
 										"dateJoined": {
-											"type": "string"
+											"type": "string",
+											"description": "Formatted UTC date string of when the account was created"
 										},
 										"uid": {
-											"type": "string"
+											"type": "string",
+											"description": "Firebase identifier of the user *data* based on the firestore document"
 										}
 									},
 									"required": [
@@ -555,9 +563,6 @@
 						]
 					}
 				},
-				"required": [
-					"data"
-				],
 				"type": "object",
 				"additionalProperties": false
 			},
@@ -1107,7 +1112,25 @@
 						]
 					}
 				],
-				"parameters": []
+				"parameters": [
+					{
+						"in": "query",
+						"name": "cursor",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "toFetch",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
 			}
 		},
 		"/admin/users/create": {

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -510,6 +510,39 @@
 				],
 				"type": "string"
 			},
+			"CombinedUserData": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/UserAdditionalInfo"
+					},
+					{
+						"properties": {
+							"membership": {
+								"$ref": "#/components/schemas/UserAccountTypes",
+								"description": "What type of account the user has"
+							},
+							"email": {
+								"type": "string",
+								"description": "The email the user uses to log in"
+							},
+							"dateJoined": {
+								"type": "string",
+								"description": "Formatted UTC date string of when the account was created"
+							},
+							"uid": {
+								"type": "string",
+								"description": "Firebase identifier of the user *data* based on the firestore document"
+							}
+						},
+						"required": [
+							"membership",
+							"email",
+							"uid"
+						],
+						"type": "object"
+					}
+				]
+			},
 			"AllUsersResponse": {
 				"properties": {
 					"error": {
@@ -523,44 +556,10 @@
 						"description": "Needed for firestore operations which do not support offset\r\nbased pagination"
 					},
 					"data": {
-						"allOf": [
-							{
-								"items": {
-									"$ref": "#/components/schemas/UserAdditionalInfo"
-								},
-								"type": "array"
-							},
-							{
-								"items": {
-									"properties": {
-										"membership": {
-											"$ref": "#/components/schemas/UserAccountTypes",
-											"description": "What type of account the user has"
-										},
-										"email": {
-											"type": "string",
-											"description": "The email the user uses to log in"
-										},
-										"dateJoined": {
-											"type": "string",
-											"description": "Formatted UTC date string of when the account was created"
-										},
-										"uid": {
-											"type": "string",
-											"description": "Firebase identifier of the user *data* based on the firestore document"
-										}
-									},
-									"required": [
-										"membership",
-										"email",
-										"dateJoined",
-										"uid"
-									],
-									"type": "object"
-								},
-								"type": "array"
-							}
-						]
+						"items": {
+							"$ref": "#/components/schemas/CombinedUserData"
+						},
+						"type": "array"
 					}
 				},
 				"type": "object",

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -28,92 +28,6 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"UserAdditionalInfo": {
-				"properties": {
-					"date_of_birth": {
-						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp"
-					},
-					"does_snowboarding": {
-						"type": "boolean"
-					},
-					"does_racing": {
-						"type": "boolean"
-					},
-					"does_ski": {
-						"type": "boolean"
-					},
-					"gender": {
-						"type": "string"
-					},
-					"emergency_contact": {
-						"type": "string"
-					},
-					"first_name": {
-						"type": "string"
-					},
-					"last_name": {
-						"type": "string"
-					},
-					"dietary_requirements": {
-						"type": "string"
-					},
-					"faculty": {
-						"type": "string"
-					},
-					"university": {
-						"type": "string"
-					},
-					"student_id": {
-						"type": "string"
-					},
-					"returning": {
-						"type": "boolean"
-					},
-					"university_year": {
-						"type": "string"
-					},
-					"stripe_id": {
-						"type": "string",
-						"description": "For identification DO NOT RETURN to users in exposed endpoints"
-					}
-				},
-				"required": [
-					"date_of_birth",
-					"does_snowboarding",
-					"does_racing",
-					"does_ski",
-					"gender",
-					"first_name",
-					"last_name",
-					"dietary_requirements",
-					"returning",
-					"university_year"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"FirebaseProperties": {
-				"properties": {
-					"uid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"uid"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"UserResponse": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/UserAdditionalInfo"
-					},
-					{
-						"$ref": "#/components/schemas/FirebaseProperties"
-					}
-				]
-			},
 			"Pick_Partial_UserAdditionalInfo_.Exclude_keyofPartial_UserAdditionalInfo_.stripe_id__": {
 				"properties": {
 					"date_of_birth": {
@@ -524,6 +438,129 @@
 				"$ref": "#/components/schemas/Pick_MakeDatesAvailableRequestBody.Exclude_keyofMakeDatesAvailableRequestBody.slots__",
 				"description": "Construct a type with the properties of T except for those in type K."
 			},
+			"UserAdditionalInfo": {
+				"properties": {
+					"date_of_birth": {
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp"
+					},
+					"does_snowboarding": {
+						"type": "boolean"
+					},
+					"does_racing": {
+						"type": "boolean"
+					},
+					"does_ski": {
+						"type": "boolean"
+					},
+					"gender": {
+						"type": "string"
+					},
+					"emergency_contact": {
+						"type": "string"
+					},
+					"first_name": {
+						"type": "string"
+					},
+					"last_name": {
+						"type": "string"
+					},
+					"dietary_requirements": {
+						"type": "string"
+					},
+					"faculty": {
+						"type": "string"
+					},
+					"university": {
+						"type": "string"
+					},
+					"student_id": {
+						"type": "string"
+					},
+					"returning": {
+						"type": "boolean"
+					},
+					"university_year": {
+						"type": "string"
+					},
+					"stripe_id": {
+						"type": "string",
+						"description": "For identification DO NOT RETURN to users in exposed endpoints"
+					}
+				},
+				"required": [
+					"date_of_birth",
+					"does_snowboarding",
+					"does_racing",
+					"does_ski",
+					"gender",
+					"first_name",
+					"last_name",
+					"dietary_requirements",
+					"returning",
+					"university_year"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UserAccountTypes": {
+				"enum": [
+					"admin",
+					"member",
+					"guest"
+				],
+				"type": "string"
+			},
+			"AllUsersResponse": {
+				"properties": {
+					"error": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"allOf": [
+							{
+								"items": {
+									"$ref": "#/components/schemas/UserAdditionalInfo"
+								},
+								"type": "array"
+							},
+							{
+								"items": {
+									"properties": {
+										"membership": {
+											"$ref": "#/components/schemas/UserAccountTypes"
+										},
+										"email": {
+											"type": "string"
+										},
+										"dateJoined": {
+											"type": "string"
+										},
+										"uid": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"membership",
+										"email",
+										"dateJoined",
+										"uid"
+									],
+									"type": "object"
+								},
+								"type": "array"
+							}
+						]
+					}
+				},
+				"required": [
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"CreateUserRequestBody": {
 				"properties": {
 					"uid": {
@@ -667,7 +704,70 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/UserResponse"
+									"properties": {
+										"stripe_id": {
+											"type": "string"
+										},
+										"university_year": {
+											"type": "string"
+										},
+										"returning": {
+											"type": "boolean"
+										},
+										"student_id": {
+											"type": "string"
+										},
+										"university": {
+											"type": "string"
+										},
+										"faculty": {
+											"type": "string"
+										},
+										"dietary_requirements": {
+											"type": "string"
+										},
+										"last_name": {
+											"type": "string"
+										},
+										"first_name": {
+											"type": "string"
+										},
+										"emergency_contact": {
+											"type": "string"
+										},
+										"gender": {
+											"type": "string"
+										},
+										"does_ski": {
+											"type": "boolean"
+										},
+										"does_racing": {
+											"type": "boolean"
+										},
+										"does_snowboarding": {
+											"type": "boolean"
+										},
+										"date_of_birth": {
+											"$ref": "#/components/schemas/FirebaseFirestore.Timestamp"
+										},
+										"uid": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"university_year",
+										"returning",
+										"dietary_requirements",
+										"last_name",
+										"first_name",
+										"gender",
+										"does_ski",
+										"does_racing",
+										"does_snowboarding",
+										"date_of_birth",
+										"uid"
+									],
+									"type": "object"
 								}
 							}
 						}
@@ -993,10 +1093,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/UserResponse"
-									},
-									"type": "array"
+									"$ref": "#/components/schemas/AllUsersResponse"
 								}
 							}
 						}

--- a/server/src/middleware/routes.test.ts
+++ b/server/src/middleware/routes.test.ts
@@ -138,6 +138,25 @@ describe("Endpoints", () => {
       )
     })
 
+    it("should reject invalid fetch quantities", async () => {
+      await createUsers()
+      let response = await request
+        .get("/admin/users")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .query({ toFetch: 101 })
+        .send({})
+
+      expect(response.status).toEqual(400)
+
+      response = await request
+        .get(`/admin/users`)
+        .set("Authorization", `Bearer ${adminToken}`)
+        .query({ toFetch: -1 })
+        .send({})
+      // we should fetch everything after the one we just got
+      expect(response.status).toEqual(400)
+    })
+
     it("should fetch merged data for users, after the offset", async () => {
       await createUsers()
       // Will fetch indexes 1,2
@@ -153,8 +172,9 @@ describe("Endpoints", () => {
       const nextCursor = response.body.nextCursor
 
       response = await request
-        .get(`/admin/users?toFetch=3&cursor=${nextCursor}`)
+        .get(`/admin/users`)
         .set("Authorization", `Bearer ${adminToken}`)
+        .query({ toFetch: 3, cursor: nextCursor })
         .send({})
       // we should fetch everything after the one we just got
       expect(response.body.data).toHaveLength(2)

--- a/server/src/middleware/routes.test.ts
+++ b/server/src/middleware/routes.test.ts
@@ -26,6 +26,7 @@ import { dateToFirestoreTimeStamp } from "data-layer/adapters/DateUtils"
 import BookingDataService from "data-layer/services/BookingDataService"
 import { Timestamp } from "firebase-admin/firestore"
 import { DEFAULT_BOOKING_MAX_SLOTS } from "business-layer/utils/BookingConstants"
+import { UserAccountTypes } from "business-layer/utils/AuthServiceClaims"
 
 const request = supertest(_app)
 
@@ -116,6 +117,21 @@ describe("Endpoints", () => {
         .set("Authorization", `Bearer ${adminToken}`)
         .send({})
         .expect(200, done)
+    })
+    it("should fetch merged data for users", async () => {
+      await createUsers()
+      const response = await request
+        .get("/admin/users")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({})
+
+      expect(response.status).toEqual(200)
+      expect(response.body.data).toHaveLength(3)
+      expect(
+        response.body.data.some(
+          (item: any) => item.membership === UserAccountTypes.ADMIN
+        )
+      )
     })
     it("Should not allow members to get users", (done) => {
       request

--- a/server/src/service-layer/controllers/AdminController.ts
+++ b/server/src/service-layer/controllers/AdminController.ts
@@ -171,9 +171,7 @@ export class AdminController extends Controller {
       if (cursor) {
         snapshot = await userDataService.getUserDocumentSnapshot(cursor)
       }
-      /**
-       * tsoa doesn't allow us to directly type the
-       */
+
       const { users: rawUserData, nextCursor: lastUid } =
         await userDataService.getAllUserData(toFetch, snapshot)
 
@@ -210,7 +208,7 @@ export class AdminController extends Controller {
         }
       })
 
-      // If there is explicitly no more users we return an `undefined` next offset
+      // If there is explicitly no more users we return an `undefined` next cursor
       let nextCursor
       if (combinedUserData.length === USERS_TO_FETCH) {
         nextCursor = lastUid

--- a/server/src/service-layer/controllers/AdminController.ts
+++ b/server/src/service-layer/controllers/AdminController.ts
@@ -190,26 +190,22 @@ export class AdminController extends Controller {
           (item) => item.uid === userInfo.uid
         )
 
-        const {
-          customClaims,
-          email,
-          metadata: { creationTime }
-        } = { ...matchingUserRecord } // to avoid undefined destructuring error
+        const { customClaims, email, metadata } = { ...matchingUserRecord } // to avoid undefined destructuring error
 
-        let membership: UserAccountTypes
+        let membership: UserAccountTypes = UserAccountTypes.GUEST
 
-        if (customClaims[AuthServiceClaims.ADMIN]) {
-          membership = UserAccountTypes.ADMIN
-        } else if (customClaims[AuthServiceClaims.MEMBER]) {
-          membership = UserAccountTypes.MEMBER
-        } else {
-          membership = UserAccountTypes.GUEST
+        if (customClaims) {
+          if (customClaims[AuthServiceClaims.ADMIN]) {
+            membership = UserAccountTypes.ADMIN
+          } else if (customClaims[AuthServiceClaims.MEMBER]) {
+            membership = UserAccountTypes.MEMBER
+          }
         }
 
         return {
           email,
           membership,
-          dateJoined: creationTime,
+          dateJoined: metadata ? metadata.creationTime : undefined,
           ...userInfo
         }
       })

--- a/server/src/service-layer/controllers/AdminController.ts
+++ b/server/src/service-layer/controllers/AdminController.ts
@@ -156,13 +156,13 @@ export class AdminController extends Controller {
   @Get("/users")
   public async getAllUsers(
     @Query() cursor?: string,
-    /**
-     * @isNumber Please enter a number
-     * @maximum 100 Maximum slots exceeded
-     * @minimum 0 must be positive
-     */
     @Query() toFetch?: number
   ): Promise<AllUsersResponse> {
+    // validation
+    if (toFetch > 100 || toFetch < 0) {
+      this.setStatus(400)
+      return { error: "Invalid fetch amount" }
+    }
     const USERS_TO_FETCH = toFetch || 100
     try {
       const userDataService = new UserDataService()

--- a/server/src/service-layer/controllers/UserController.ts
+++ b/server/src/service-layer/controllers/UserController.ts
@@ -4,7 +4,6 @@ import {
   SelfRequestModel,
   EditSelfRequestModel
 } from "service-layer/request-models/UserRequests"
-import { UserResponse } from "service-layer/response-models/UserResponse"
 import {
   Body,
   Controller,
@@ -21,9 +20,7 @@ export class UsersController extends Controller {
   @SuccessResponse("200", "Fetched self data")
   @Security("jwt")
   @Get("self")
-  public async getSelf(
-    @Request() request: SelfRequestModel
-  ): Promise<UserResponse> {
+  public async getSelf(@Request() request: SelfRequestModel) {
     const data = await new UserDataService().getUserData(request.user.uid)
 
     // Don't want users editing this

--- a/server/src/service-layer/response-models/CommonResponse.ts
+++ b/server/src/service-layer/response-models/CommonResponse.ts
@@ -7,7 +7,7 @@ export interface OffsetPaginatedResponse {
   /**
    * Indicates the offset that would give the next page of data
    *
-   * **Will be undefined in case of no next offset**
+   * **Will be undefined in case of last page**
    */
   nextOffset?: number
 }
@@ -16,6 +16,8 @@ export interface CursorPaginatedResponse {
   /**
    * Needed for firestore operations which do not support offset
    * based pagination
+   *
+   * **Will be undefined in case of last page**
    */
   nextCursor?: string
 }

--- a/server/src/service-layer/response-models/CommonResponse.ts
+++ b/server/src/service-layer/response-models/CommonResponse.ts
@@ -2,3 +2,20 @@ export interface CommonResponse {
   error?: string
   message?: string
 }
+
+export interface OffsetPaginatedResponse {
+  /**
+   * Indicates the offset that would give the next page of data
+   *
+   * **Will be undefined in case of no next offset**
+   */
+  nextOffset?: number
+}
+
+export interface CursorPaginatedResponse {
+  /**
+   * Needed for firestore operations which do not support offset
+   * based pagination
+   */
+  nextCursor?: string
+}

--- a/server/src/service-layer/response-models/UserResponse.ts
+++ b/server/src/service-layer/response-models/UserResponse.ts
@@ -2,26 +2,27 @@ import { UserAdditionalInfo } from "data-layer/models/firebase"
 import { CommonResponse, CursorPaginatedResponse } from "./CommonResponse"
 import { UserAccountTypes } from "business-layer/utils/AuthServiceClaims"
 
+type CombinedUserData = UserAdditionalInfo & {
+  /**
+   * Firebase identifier of the user *data* based on the firestore document
+   */
+  uid: string
+  /**
+   * Formatted UTC date string of when the account was created
+   */
+  dateJoined?: string
+  /**
+   * The email the user uses to log in
+   */
+  email: string
+  /**
+   * What type of account the user has
+   */
+  membership: UserAccountTypes
+}
+
 export interface AllUsersResponse
   extends CommonResponse,
     CursorPaginatedResponse {
-  data?: UserAdditionalInfo[] &
-    {
-      /**
-       * Firebase identifier of the user *data* based on the firestore document
-       */
-      uid: string
-      /**
-       * Formatted UTC date string of when the account was created
-       */
-      dateJoined: string
-      /**
-       * The email the user uses to log in
-       */
-      email: string
-      /**
-       * What type of account the user has
-       */
-      membership: UserAccountTypes
-    }[]
+  data?: CombinedUserData[]
 }

--- a/server/src/service-layer/response-models/UserResponse.ts
+++ b/server/src/service-layer/response-models/UserResponse.ts
@@ -1,9 +1,11 @@
 import { UserAdditionalInfo } from "data-layer/models/firebase"
-import { CommonResponse } from "./CommonResponse"
+import { CommonResponse, CursorPaginatedResponse } from "./CommonResponse"
 import { UserAccountTypes } from "business-layer/utils/AuthServiceClaims"
 
-export interface AllUsersResponse extends CommonResponse {
-  data: UserAdditionalInfo[] &
+export interface AllUsersResponse
+  extends CommonResponse,
+    CursorPaginatedResponse {
+  data?: UserAdditionalInfo[] &
     {
       /**
        * Firebase identifier of the user *data* based on the firestore document

--- a/server/src/service-layer/response-models/UserResponse.ts
+++ b/server/src/service-layer/response-models/UserResponse.ts
@@ -5,9 +5,21 @@ import { UserAccountTypes } from "business-layer/utils/AuthServiceClaims"
 export interface AllUsersResponse extends CommonResponse {
   data: UserAdditionalInfo[] &
     {
+      /**
+       * Firebase identifier of the user *data* based on the firestore document
+       */
       uid: string
+      /**
+       * Formatted UTC date string of when the account was created
+       */
       dateJoined: string
+      /**
+       * The email the user uses to log in
+       */
       email: string
+      /**
+       * What type of account the user has
+       */
       membership: UserAccountTypes
     }[]
 }

--- a/server/src/service-layer/response-models/UserResponse.ts
+++ b/server/src/service-layer/response-models/UserResponse.ts
@@ -1,4 +1,13 @@
-import { FirebaseProperties } from "data-layer/models/common"
 import { UserAdditionalInfo } from "data-layer/models/firebase"
+import { CommonResponse } from "./CommonResponse"
+import { UserAccountTypes } from "business-layer/utils/AuthServiceClaims"
 
-export type UserResponse = UserAdditionalInfo & FirebaseProperties
+export interface AllUsersResponse extends CommonResponse {
+  data: UserAdditionalInfo[] &
+    {
+      uid: string
+      dateJoined: string
+      email: string
+      membership: UserAccountTypes
+    }[]
+}


### PR DESCRIPTION
# Proper data on admin member view

closes #149 

Have also implemented pagination as this would be limited to 100 user objects/request

![image](https://github.com/UoaWDCC/uasc-web/assets/100653148/71e1c9f9-1439-40fa-bb03-004fce8aae91)

Data omitted due to real information 

## Notable changes

- New callback `onPageChange` which notifies of when an attempt should be made for fetching the next "page" of data
-  Introduced base types for paginated responses in `CommonResponse` - note a cursor based one exists as firestore doesn't support offset based
- Switched to `useInfiniteQuery` to allow for easier pagination on FE