### PR TITLE
Refresh user tokens on pages that require it

### DIFF
--- a/client/src/components/composite/SignUpForm/PageConfig/PageConfig.tsx
+++ b/client/src/components/composite/SignUpForm/PageConfig/PageConfig.tsx
@@ -47,7 +47,8 @@ export const PAGINATED_FORM_PAGES = (
   navigateFn: (route: RouteNames | "/profile" | number) => void,
   signUpFn: FormSubmissionMutationFunction,
   validateFormFn: (pageToValidate: PAGES, navigateFn: () => void) => void,
-  disableSubmit: boolean
+  disableSubmit: boolean,
+  isSignedIn: boolean = false
 ): PageProps[] => [
   {
     index: PAGES.PersonalFirst,
@@ -108,7 +109,9 @@ export const PAGINATED_FORM_PAGES = (
   {
     index: PAGES.Confirm,
     title: "Confirm",
-    onNext: () => navigateFn(ACCOUNT_SETUP_ROUTE)
+    onNext: () => navigateFn(ACCOUNT_SETUP_ROUTE),
+    nextDisabled: !isSignedIn,
+    backDisabled: !isSignedIn
   },
   {
     index: PAGES.AccountSetup,

--- a/client/src/hooks/useRefreshedToken.ts
+++ b/client/src/hooks/useRefreshedToken.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react"
+import { useAppData } from "store/Store"
+
+/**
+ * Used to force refresh a user token, on first render of the hook
+ *
+ * The use case is for when custom claims change and need to be reflected
+ *
+ * @example useForceRefreshToken()
+ */
+export const useForceRefreshToken = () => {
+  const [{ currentUser }, { refreshUserToken }] = useAppData()
+  /*
+   * Refresh the token on **First** page load only
+   * in case they try to navigate to this page right
+   * after signing up
+   */
+  useEffect(() => {
+    if (currentUser) refreshUserToken()
+  }, [currentUser])
+}

--- a/client/src/pages/Booking.tsx
+++ b/client/src/pages/Booking.tsx
@@ -2,8 +2,11 @@ import { ProtectedCreateBookingSection } from "components/composite/BookingCreat
 import { Route, Routes } from "react-router-dom"
 import BookingSuccess from "./BookingSuccess"
 import { Footer } from "components/generic/Footer/Footer"
+import { useForceRefreshToken } from "hooks/useRefreshedToken"
 
 const Booking = () => {
+  useForceRefreshToken()
+
   return (
     <>
       <div

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -4,12 +4,16 @@ import { useNavigate } from "react-router-dom"
 import ProfileInformationPanel from "components/generic/ProfileInformationPanel/ProfileInformationPanel"
 import { Footer } from "components/generic/Footer/Footer"
 import ResponsiveBackgroundImage from "components/generic/ResponsiveBackgroundImage/ResponsiveBackground"
+import { useForceRefreshToken } from "hooks/useRefreshedToken"
 
 const SignOutButton = () => {
   const navigate = useNavigate()
   const handleOnclick = () => {
     navigate("/login")
   }
+
+  useForceRefreshToken()
+
   return (
     <div
       className="border-red space-x-4; disabled:bg-gray-3 text-red hover:bg-red

--- a/client/src/pages/Register/Register.tsx
+++ b/client/src/pages/Register/Register.tsx
@@ -40,7 +40,8 @@ const Register = () => {
     navigateFn!,
     mutate,
     validateForm,
-    isPending || successfullySignedUp
+    isPending || successfullySignedUp,
+    !!currentUser
   )
   const pageContent = PAGE_CONTENT
 


### PR DESCRIPTION
Have called the store action created in #284 on the:
- `bookings` 
- `profile`
pages so that the user can see up to date information about the views.

The user may now *not* navigate away from the payment confirmation page until their account has been logged back in by firebase