### PR TITLE
Improve date handling on frontend

### DIFF
--- a/client/src/components/composite/Booking/BookingCreation/BookingCreation.tsx
+++ b/client/src/components/composite/Booking/BookingCreation/BookingCreation.tsx
@@ -114,6 +114,10 @@ export const CreateBookingSection = ({
    */
   const checkValidRange = (startDate: Date, endDate: Date) => {
     const dateArray = datesToDateRange(startDate, endDate)
+    if (dateArray.length > 10) {
+      alert("You may only book up to 10 days max.")
+      return false
+    }
     if (
       dateArray.some(
         (date) =>

--- a/client/src/components/utils/Utils.tsx
+++ b/client/src/components/utils/Utils.tsx
@@ -15,8 +15,7 @@ export const isSingleFridayOrSaturday = (startDate: Date, endDate: Date) => {
   const SATURDAY = 6
   const dateArray = datesToDateRange(startDate, endDate)
   return (
-    dateArray.length === 1 &&
-    [FRIDAY, SATURDAY].includes(dateArray[0].getUTCDay())
+    dateArray.length === 1 && [FRIDAY, SATURDAY].includes(dateArray[0].getDay())
   )
 }
 

--- a/client/src/services/Payment/PaymentService.ts
+++ b/client/src/services/Payment/PaymentService.ts
@@ -44,7 +44,7 @@ const PaymentService = {
 
     if (!data?.stripeClientSecret) {
       throw new Error(
-        "An error occured when trying to fetch the membership payment client secret"
+        "An error occured when trying to fetch the booking payment client secret"
       )
     }
 

--- a/server/src/business-layer/services/StripeService.ts
+++ b/server/src/business-layer/services/StripeService.ts
@@ -268,6 +268,7 @@ export default class StripeService {
    * @param line_item format `{price: <price id of item>, quantity: X}`
    * @param metadata KVP of metadata
    * @param expires_after_mins Must be over 30 and under 24 hours (1140) we default to 31 minutes
+   * @param custom_text Object representing [extra text](https://docs.stripe.com/payments/checkout/customization) that the user may need to see
    * @returns client secret
    */
   public async createCheckoutSession(
@@ -279,7 +280,8 @@ export default class StripeService {
     }[],
     metadata: Record<string, string>,
     customer_id: string,
-    expires_after_mins: number = 31
+    expires_after_mins: number = 31,
+    custom_text?: Stripe.Checkout.SessionCreateParams.CustomText
   ) {
     const session = await stripe.checkout.sessions.create({
       // consumer changeable
@@ -292,7 +294,8 @@ export default class StripeService {
       ui_mode: "embedded",
       mode: "payment",
       currency: "NZD",
-      expires_at: dateNowSecs() + expires_after_mins * ONE_MINUTE_S
+      expires_at: dateNowSecs() + expires_after_mins * ONE_MINUTE_S,
+      custom_text
     })
     return session.client_secret
   }

--- a/server/src/business-layer/utils/BookingUtils.ts
+++ b/server/src/business-layer/utils/BookingUtils.ts
@@ -81,7 +81,7 @@ const BookingUtils = {
     if (
       // Single day requested
       totalDays === 1 &&
-      [FRIDAY, SATURDAY].includes(datesInBooking[0].getUTCDay())
+      [FRIDAY, SATURDAY].includes(datesInBooking[0].getDay())
     ) {
       return LodgePricingTypeValues.SingleFridayOrSaturday
     } else {

--- a/server/src/service-layer/controllers/PaymentController.ts
+++ b/server/src/service-layer/controllers/PaymentController.ts
@@ -413,7 +413,13 @@ export class PaymentController extends Controller {
             bookingSlots.map((slot) => slot.id)
           )
         },
-        stripeCustomerId
+        stripeCustomerId,
+        undefined,
+        {
+          submit: {
+            message: `By clicking Pay you agree to booking the nights from ${BOOKING_START_DATE} to ${BOOKING_END_DATE}`
+          }
+        }
       )
       this.setStatus(200)
       return {

--- a/server/src/service-layer/controllers/PaymentController.ts
+++ b/server/src/service-layer/controllers/PaymentController.ts
@@ -307,8 +307,8 @@ export class PaymentController extends Controller {
       }
 
       const datesInBooking = datesToDateRange(
-        firestoreTimestampToDate(startDate),
-        firestoreTimestampToDate(endDate)
+        firestoreTimestampToDate(normaliseFirestoreTimeStamp(startDate)),
+        firestoreTimestampToDate(normaliseFirestoreTimeStamp(endDate))
       )
 
       const totalDays = datesInBooking.length
@@ -393,10 +393,9 @@ export class PaymentController extends Controller {
       )
       const { default_price } = requiredBookingProduct
 
-      const BOOKING_START_DATE = datesInBooking[0].toISOString().split("T")[0]
-      const BOOKING_END_DATE = datesInBooking[totalDays - 1]
-        .toISOString()
-        .split("T")[0]
+      const BOOKING_START_DATE = datesInBooking[0].toLocaleDateString("en-NZ")
+      const BOOKING_END_DATE =
+        datesInBooking[totalDays - 1].toLocaleDateString("en-NZ")
 
       const clientSecret = await stripeService.createCheckoutSession(
         uid,


### PR DESCRIPTION
The problem before is the different timezones on the frontend return different dates from the date inputs. The fix here is to use `getDay` on the front end (to display the appropriate data to the user) and backend **but** on the back end need to re-parse the date to its timezone to account for differences. 

- Switch to getDay instead of getUTCDay (helps to resolve the issue of dates getting "pushed back" one day)
- Add check on frontend to disallow selection of 10 > nights
- Display the dates the current booking is for in the checkout session
