### PR TITLE
Allow admins to delete users

### DIFF
--- a/client/src/components/composite/Admin/AdminMemberView/AdminMemberView.tsx
+++ b/client/src/components/composite/Admin/AdminMemberView/AdminMemberView.tsx
@@ -44,6 +44,11 @@ interface IAdminMemberView {
    * used to fetch the data once the last page of the table has been reached
    */
   fetchNextPage?: () => void
+
+  /**
+   * Used to indicate if there is currently an operation going on
+   */
+  isUpdating?: boolean
 }
 
 /**
@@ -62,7 +67,8 @@ const ADMIN_MEMBER_VIEW_MIN_SEARCH_QUERY_LENGTH = 2 as const
 export const AdminMemberView = ({
   data,
   rowOperations,
-  fetchNextPage
+  fetchNextPage,
+  isUpdating
 }: IAdminMemberView) => {
   const [currentSearchQuery, setCurrentSearchQuery] = useState<string>("")
   const [isLastPage, setIsLastPage] = useState<boolean>(false)
@@ -87,7 +93,9 @@ export const AdminMemberView = ({
     setCurrentSearchQuery(newQuery)
   }
   return (
-    <>
+    <div
+      className={`w-full ${isUpdating ? "brightness-75" : "brightness-100"}`}
+    >
       <span className="mb-4 mt-6 flex w-full justify-between">
         <span className="flex gap-5">
           <AdminSearchBar onQueryChanged={onSeachQueryChangedHandler} />
@@ -105,6 +113,6 @@ export const AdminMemberView = ({
           setIsLastPage(last)
         }}
       />
-    </>
+    </div>
   )
 }

--- a/client/src/components/composite/Admin/AdminMemberView/ProtectedAdminMemberView.tsx
+++ b/client/src/components/composite/Admin/AdminMemberView/ProtectedAdminMemberView.tsx
@@ -54,6 +54,13 @@ const WrappedAdminMemberView = () => {
         const matchingUser = transformedDataList?.find(
           (user) => user.uid === uid
         )
+        /**
+         * This should be enforced in the endpoint anyway, exists for UX
+         */
+        if (matchingUser?.Status === "admin") {
+          alert("You may not delete admins")
+          return
+        }
         if (
           confirm(
             `Are you SURE you want to delete the user ${matchingUser?.Name} (${matchingUser?.Email}). This action can NOT be undone!!!`

--- a/client/src/components/composite/Admin/AdminMemberView/ProtectedAdminMemberView.tsx
+++ b/client/src/components/composite/Admin/AdminMemberView/ProtectedAdminMemberView.tsx
@@ -1,6 +1,7 @@
 import { useUsersQuery } from "services/Admin/AdminQueries"
 import { AdminMemberView, MemberColumnFormat } from "./AdminMemberView"
 import {
+  useDeleteUserMutation,
   useDemoteUserMutation,
   usePromoteUserMutation
 } from "services/Admin/AdminMutations"
@@ -29,6 +30,7 @@ const WrappedAdminMemberView = () => {
 
   const { mutateAsync: promoteUser } = usePromoteUserMutation()
   const { mutateAsync: demoteUser } = useDemoteUserMutation()
+  const { mutateAsync: deleteUser, isPending } = useDeleteUserMutation()
 
   /**
    * You should optimistically handle the mutations in `AdminMutations`
@@ -48,9 +50,16 @@ const WrappedAdminMemberView = () => {
     },
     {
       name: "delete",
-      handler: () => {
-        // TODO
-        throw new Error("Not Implemented")
+      handler: (uid: string) => {
+        const matchingUser = transformedDataList?.find(
+          (user) => user.uid === uid
+        )
+        if (
+          confirm(
+            `Are you SURE you want to delete the user ${matchingUser?.Name} (${matchingUser?.Email}). This action can NOT be undone!!!`
+          )
+        )
+          deleteUser({ uid })
       }
     },
     {
@@ -67,6 +76,7 @@ const WrappedAdminMemberView = () => {
       fetchNextPage={() => {
         !isFetchingNextPage && hasNextPage && fetchNextPage()
       }}
+      isUpdating={isPending}
       rowOperations={rowOperations}
       data={transformedDataList}
     />

--- a/client/src/components/generic/ReusableTable/Table.tsx
+++ b/client/src/components/generic/ReusableTable/Table.tsx
@@ -83,7 +83,10 @@ export const OperationButton = <
                   data-testid={`multiple-operation-item-${index}`}
                   className="hover:text-light-blue-100 cursor-pointer select-none"
                   key={operation.name}
-                  onClick={() => operation.handler(uid)}
+                  onClick={() => {
+                    operation.handler(uid)
+                    setIsOpen(false)
+                  }}
                 >
                   {operation.name}
                 </p>

--- a/client/src/services/Admin/AdminMutations.ts
+++ b/client/src/services/Admin/AdminMutations.ts
@@ -58,6 +58,17 @@ export function useDemoteUserMutation() {
   })
 }
 
+export function useDeleteUserMutation() {
+  return useMutation({
+    mutationKey: ["delete-user"],
+    mutationFn: AdminService.deleteUser,
+    retry: 0,
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: [ALL_USERS_QUERY] })
+    }
+  })
+}
+
 export function useMakeDatesAvailableMutation(
   startDate?: Timestamp,
   endDate?: Timestamp,

--- a/client/src/services/Admin/AdminService.ts
+++ b/client/src/services/Admin/AdminService.ts
@@ -50,6 +50,14 @@ const AdminService = {
     })
     if (!response.ok) throw new Error(`Failed to promote ${uid}`)
   },
+  deleteUser: async function ({ uid }: { uid: string }) {
+    const { response } = await fetchClient.DELETE("/users/delete-user", {
+      body: {
+        uid
+      }
+    })
+    if (!response.ok) throw new Error(`Failed to delete user ${uid}`)
+  },
   makeDatesAvailable: async function (
     startDate: Timestamp,
     endDate: Timestamp,

--- a/server/src/service-layer/controllers/UserController.ts
+++ b/server/src/service-layer/controllers/UserController.ts
@@ -77,7 +77,6 @@ export class UsersController extends Controller {
         } catch (e) {
           console.info(`Couldn't fetch user claims for ${userUid}. ${e}`)
         }
-        console.log(userClaims)
         if (userClaims && userClaims[AuthServiceClaims.ADMIN]) {
           this.setStatus(403) // forbidden request
           return { error: "Cannot delete another admin." }

--- a/server/src/service-layer/controllers/UserController.ts
+++ b/server/src/service-layer/controllers/UserController.ts
@@ -18,6 +18,7 @@ import {
   Patch,
   Delete
 } from "tsoa"
+import { AuthServiceClaims } from "business-layer/utils/AuthServiceClaims"
 
 @Route("users")
 export class UsersController extends Controller {
@@ -70,15 +71,30 @@ export class UsersController extends Controller {
         const authService = new AuthService()
         const userDataService = new UserDataService()
 
-        const userClaims = await authService.getCustomerUserClaim(userUid)
-        if (userClaims && userClaims.admin) {
+        let userClaims
+        try {
+          userClaims = await authService.getCustomerUserClaim(userUid)
+        } catch (e) {
+          console.info(`Couldn't fetch user claims for ${userUid}. ${e}`)
+        }
+        console.log(userClaims)
+        if (userClaims && userClaims[AuthServiceClaims.ADMIN]) {
           this.setStatus(403) // forbidden request
           return { error: "Cannot delete another admin." }
         }
 
         this.setStatus(200)
-        await authService.deleteUser(userUid)
-        await userDataService.deleteUserData(userUid)
+        try {
+          await authService.deleteUser(userUid)
+        } catch (e) {
+          console.info(`Couldn't delete ${userUid} in auth. ${e}`)
+        }
+
+        try {
+          await userDataService.deleteUserData(userUid)
+        } catch (e) {
+          console.info(`Couldn't delete ${userUid} in firestore. ${e}`)
+        }
       }
     } catch (err) {
       this.setStatus(500)

--- a/server/src/service-layer/controllers/UserController.ts
+++ b/server/src/service-layer/controllers/UserController.ts
@@ -71,7 +71,7 @@ export class UsersController extends Controller {
         const userDataService = new UserDataService()
 
         const userClaims = await authService.getCustomerUserClaim(userUid)
-        if (userClaims.admin) {
+        if (userClaims && userClaims.admin) {
           this.setStatus(403) // forbidden request
           return { error: "Cannot delete another admin." }
         }
@@ -82,6 +82,7 @@ export class UsersController extends Controller {
       }
     } catch (err) {
       this.setStatus(500)
+      console.error(err)
       return { error: "Failed to delete user." }
     }
   }


### PR DESCRIPTION
Had to make some changes to the endpoint made in #408, because in some cases we still want to carry out all the steps even if the previous ones failed. Also introduced an `isUpdating` prop to give feedback that a deletion is happening

![delete users](https://github.com/UoaWDCC/uasc-web/assets/100653148/27d42edb-6279-4555-87bb-78889a0d16d9)
