### PR TITLE
format dates properly for display

### DIFF
--- a/server/src/service-layer/controllers/PaymentController.ts
+++ b/server/src/service-layer/controllers/PaymentController.ts
@@ -397,9 +397,13 @@ export class PaymentController extends Controller {
       )
       const { default_price } = requiredBookingProduct
 
-      const BOOKING_START_DATE = datesInBooking[0].toLocaleDateString("en-NZ")
-      const BOOKING_END_DATE =
-        datesInBooking[totalDays - 1].toLocaleDateString("en-NZ")
+      const BOOKING_START_DATE = new Date(
+        datesInBooking[0].toDateString()
+      ).toLocaleDateString("en-NZ")
+
+      const BOOKING_END_DATE = new Date(
+        datesInBooking[totalDays - 1].toDateString()
+      ).toLocaleDateString("en-NZ")
 
       const clientSecret = await stripeService.createCheckoutSession(
         uid,


### PR DESCRIPTION
The changes in #463 meant that while the bookings were functionally correct, the displayed dates to the user were wrong. This is why we have to normalise the dates to make the correct ones displayed (to be consistent with the ones in admin view - #431 for further discussion) 