### PR TITLE
Fix typo in prod server workflow, and update the environments associated with each

### DIFF
--- a/.github/workflows/deploy-client-production.yml
+++ b/.github/workflows/deploy-client-production.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   Deploy-Client:
     runs-on: ubuntu-latest
-    environment: DEV
+    environment: Client Production
     defaults:
       run:
         working-directory: ./client

--- a/.github/workflows/deploy-server.production.yml
+++ b/.github/workflows/deploy-server.production.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl secrets set --config fly.production.toml "GOOGLE_SERVICE_ACCOUNT_JSON=$(echo ${{ secrets.PROD_SERVER_SERVICE_ACCOUNT }} | base64 --decode)" STRIPE_WEBHOOK_SECRET=${{ secrets.PROD_SERVER_STRIPE_WEBHOOK_SECRET }} STRIPE_API_SECRET=${{ secrets.PROD_SERVER_STRIPE_API_SECRET } FRONTEND_URL=${{ secrets.PROD_FRONTEND_URL }}
+      - run: flyctl secrets set --config fly.production.toml "GOOGLE_SERVICE_ACCOUNT_JSON=$(echo ${{ secrets.PROD_SERVER_SERVICE_ACCOUNT }} | base64 --decode)" STRIPE_WEBHOOK_SECRET=${{ secrets.PROD_SERVER_STRIPE_WEBHOOK_SECRET }} STRIPE_API_SECRET=${{ secrets.PROD_SERVER_STRIPE_API_SECRET }} FRONTEND_URL=${{ secrets.PROD_FRONTEND_URL }}
       - run: flyctl secrets deploy --config fly.production.toml
       - run: flyctl deploy --remote-only --config fly.production.toml

--- a/.github/workflows/deploy-server.production.yml
+++ b/.github/workflows/deploy-server.production.yml
@@ -9,6 +9,7 @@ jobs:
   deploy-api:
     name: Deploy Api
     runs-on: ubuntu-latest
+    environment: Server Production
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master


### PR DESCRIPTION
The prod deployment wouldn't run due to missing `}` and also remade the environements to be more specific