### PR TITLE
add error boundary for components

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "react": "^18.2.0",
     "react-calendar": "^5.0.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.13",
     "react-firebase-hooks": "^5.1.1",
     "react-router-dom": "^6.10.0",
     "react-sweet-state": "^2.7.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,8 @@ import queryClient from "services/QueryClient"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { AllRoutes } from "./routes/routes"
 import { AppNavbar } from "components/composite/Navbar/AppNavbar"
+import { ErrorBoundary } from "react-error-boundary"
+import RefreshNotification from "pages/RefreshNotification/RefreshNotification"
 
 function App() {
   return (
@@ -10,7 +12,14 @@ function App() {
       <BrowserRouter>
         <AppNavbar />
         <div className="pt-[51px]">
-          <AllRoutes />
+          <ErrorBoundary
+            fallback={<RefreshNotification />}
+            onError={() => {
+              window.location.reload()
+            }}
+          >
+            <AllRoutes />
+          </ErrorBoundary>
         </div>
       </BrowserRouter>
     </QueryClientProvider>

--- a/client/src/pages/RefreshNotification/RefreshNotification.story.tsx
+++ b/client/src/pages/RefreshNotification/RefreshNotification.story.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import RefreshNotification from "./RefreshNotification"
+const meta: Meta<typeof RefreshNotification> = {
+  component: RefreshNotification
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const DefaultRefreshNotification: Story = {
+  args: {}
+}

--- a/client/src/pages/RefreshNotification/RefreshNotification.tsx
+++ b/client/src/pages/RefreshNotification/RefreshNotification.tsx
@@ -1,5 +1,7 @@
 /**
  * Used for if there is a lazy load error due to a chunk not being found
+ *
+ * Also catches any unhandled errors
  */
 const RefreshNotification = () => {
   return (

--- a/client/src/pages/RefreshNotification/RefreshNotification.tsx
+++ b/client/src/pages/RefreshNotification/RefreshNotification.tsx
@@ -5,7 +5,7 @@ const RefreshNotification = () => {
   return (
     <div className="flex h-screen w-full items-center justify-center">
       <h2 className="text-dark-blue-100">
-        A new version of the site is ready. Please refresh the page
+        Something went wrong. Please refresh the page
       </h2>
     </div>
   )

--- a/client/src/pages/RefreshNotification/RefreshNotification.tsx
+++ b/client/src/pages/RefreshNotification/RefreshNotification.tsx
@@ -1,0 +1,14 @@
+/**
+ * Used for if there is a lazy load error due to a chunk not being found
+ */
+const RefreshNotification = () => {
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <h2 className="text-dark-blue-100">
+        A new version of the site is ready. Please refresh the page
+      </h2>
+    </div>
+  )
+}
+
+export default RefreshNotification

--- a/yarn.lock
+++ b/yarn.lock
@@ -8249,6 +8249,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-calendar: "npm:^5.0.0"
     react-dom: "npm:^18.2.0"
+    react-error-boundary: "npm:^4.0.13"
     react-firebase-hooks: "npm:^5.1.1"
     react-router-dom: "npm:^6.10.0"
     react-sweet-state: "npm:^2.7.1"
@@ -16351,6 +16352,17 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: 10c0/0d60a0ea758529c32a706d0c69d70b69fb94de3c46442fffdee34f08f51ffceddbb5395b41dfd1565895653e9f60f98ca525835be9d5db1f16d6b22be12f4cd4
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^4.0.13":
+  version: 4.0.13
+  resolution: "react-error-boundary@npm:4.0.13"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 10c0/6f3e0e4d7669f680ccf49c08c9571519c6e31f04dcfc30a765a7136c7e6fbbbe93423dd5a9fce12107f8166e54133e9dd5c2079a00c7a38201ac811f7a28b8e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Now when an error is thrown the user will be told to refresh the page instead of getting a blank screen.