### PR TITLE
639 Add Cron Workflow to Deploy Stable

### DIFF
--- a/.github/workflows/deploy-client-production.yml
+++ b/.github/workflows/deploy-client-production.yml
@@ -2,9 +2,6 @@ name: Deploy Production Build of Client for UASC
 
 on:
   workflow_dispatch:
-  # schedules this to run every day, at 00:00 UTC
-  schedule:
-    - cron: "0 0 * * *"
 
 env:
   NEXT_PUBLIC_FIREBASE_API_KEY: ${{secrets.PROD_FIREBASE_API_KEY}}

--- a/.github/workflows/deploy-client-production.yml
+++ b/.github/workflows/deploy-client-production.yml
@@ -1,7 +1,6 @@
 name: Deploy Production Build of Client for UASC
 
-on:
-  workflow_dispatch:
+on: [workflow_dispatch]
 
 env:
   NEXT_PUBLIC_FIREBASE_API_KEY: ${{secrets.PROD_FIREBASE_API_KEY}}

--- a/.github/workflows/deploy-client-stable.yml
+++ b/.github/workflows/deploy-client-stable.yml
@@ -1,0 +1,45 @@
+name: Deploy the Stable Build of Client for UASC
+
+on:
+  workflow_run:
+    branches:
+      - stable
+  workflow_dispatch:
+  # schedules this to run every day, at 00:00 UTC
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  NEXT_PUBLIC_FIREBASE_API_KEY: ${{secrets.PROD_FIREBASE_API_KEY}}
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{secrets.PROD_FIREBASE_AUTH_DOMAIN}}
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{secrets.PROD_FIREBASE_PROJECT_ID}}
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{secrets.PROD_FIREBASE_STORAGE_BUCKET}}
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.PROD_FIREBASE_MESSAGING_SENDER_ID}}
+  NEXT_PUBLIC_FIREBASE_APP_ID: ${{secrets.PROD_FIREBASE_APP_ID}}
+  NEXT_PUBLIC_BACKEND_BASE_URL: ${{secrets.PROD_BACKEND_BASE_URL}}
+  NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{secrets.PROD_MEASUREMENT_ID}}
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{secrets.PROD_STRIPE_PK}}
+  NEXT_PUBLIC_SANITY_PROJECT_ID: ${{secrets.PROD_SANITY_PROJECT_ID}}
+  NEXT_PUBLIC_SANITY_DATASET: production
+  NEXT_CONFIG_ENV: production
+
+jobs:
+  Deploy-Client:
+    runs-on: ubuntu-latest
+    environment: Client Stable
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install volta
+        uses: volta-cli/action@v4
+
+      - run: yarn workspaces focus client && yarn workspace client build
+
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_UASC_PROD }}"
+          channelId: live
+          projectId: uasc-prod
+          entryPoint: client

--- a/.github/workflows/deploy-client-stable.yml
+++ b/.github/workflows/deploy-client-stable.yml
@@ -1,45 +1,15 @@
 name: Deploy the Stable Build of Client for UASC
 
 on:
-  workflow_run:
-    branches:
-      - stable
   workflow_dispatch:
   # schedules this to run every day, at 00:00 UTC
   schedule:
     - cron: "0 0 * * *"
 
-env:
-  NEXT_PUBLIC_FIREBASE_API_KEY: ${{secrets.PROD_FIREBASE_API_KEY}}
-  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{secrets.PROD_FIREBASE_AUTH_DOMAIN}}
-  NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{secrets.PROD_FIREBASE_PROJECT_ID}}
-  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{secrets.PROD_FIREBASE_STORAGE_BUCKET}}
-  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.PROD_FIREBASE_MESSAGING_SENDER_ID}}
-  NEXT_PUBLIC_FIREBASE_APP_ID: ${{secrets.PROD_FIREBASE_APP_ID}}
-  NEXT_PUBLIC_BACKEND_BASE_URL: ${{secrets.PROD_BACKEND_BASE_URL}}
-  NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{secrets.PROD_MEASUREMENT_ID}}
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{secrets.PROD_STRIPE_PK}}
-  NEXT_PUBLIC_SANITY_PROJECT_ID: ${{secrets.PROD_SANITY_PROJECT_ID}}
-  NEXT_PUBLIC_SANITY_DATASET: production
-  NEXT_CONFIG_ENV: production
-
 jobs:
-  Deploy-Client:
+  Deploy-Stable:
     runs-on: ubuntu-latest
     environment: Client Stable
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Install volta
-        uses: volta-cli/action@v4
-
-      - run: yarn workspaces focus client && yarn workspace client build
-
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_UASC_PROD }}"
-          channelId: live
-          projectId: uasc-prod
-          entryPoint: client
+      - run: gh workflow run 'Deploy Production Build of Client for UASC' --ref stable

--- a/.github/workflows/deploy-client-stable.yml
+++ b/.github/workflows/deploy-client-stable.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Deploy-Stable:
     runs-on: ubuntu-latest
-    environment: Client Stable
+    environment: Client Production
 
     steps:
       - run: gh workflow run 'Deploy Production Build of Client for UASC' --ref stable

--- a/.github/workflows/deploy-client-stable.yml
+++ b/.github/workflows/deploy-client-stable.yml
@@ -2,9 +2,9 @@ name: Deploy the Stable Build of Client for UASC
 
 on:
   workflow_dispatch:
-  # schedules this to run every day, at 00:00 UTC
+  # schedules this to run 30 minutes
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "30 * * * *"
 
 jobs:
   Deploy-Stable:


### PR DESCRIPTION
Added the new workflow and enabled cron schedule to update stable branch to the production app.
Removed the cron schedule from the master workflow, can only manually update production through master. 