### PR TITLE
287 Remove payment intent check in membership payment

### DIFF
--- a/server/src/business-layer/services/StripeService.ts
+++ b/server/src/business-layer/services/StripeService.ts
@@ -105,25 +105,6 @@ export default class StripeService {
   }
 
   /**
-   * Checks for processing payments from a user. Used to avoid
-   * users from double paying after completing a checkout session for membership payments.
-   *
-   * @warning This assumes that users won't be paying for membership right after booking
-   *
-   * @param customerId `stripe_id` from the firebase document
-   */
-  public async hasProcessingPaymentIntent(customerId: string) {
-    const { data } = await stripe.paymentIntents.list({
-      customer: customerId
-    })
-    const hasProcessingPaymentIntent = !!data.find(
-      (intent) => intent.status === "processing"
-    )
-
-    return hasProcessingPaymentIntent
-  }
-
-  /**
    *
    * Checks for processing payments from a user. Used to avoid
    * users from double paying after completing a checkout session for membership payments.

--- a/server/src/service-layer/controllers/PaymentController.ts
+++ b/server/src/service-layer/controllers/PaymentController.ts
@@ -173,14 +173,13 @@ export class PaymentController extends Controller {
           }
         }
         /**
-         * See if user has pending payment or has recently paid -> if user didn't have a stripe id that means
+         * See if user has recently paid -> if user didn't have a stripe id that means
          * they couldn't have a completed session
          */
         if (
-          (await stripeService.hasRecentlyCompletedCheckoutSession(
+          await stripeService.hasRecentlyCompletedCheckoutSession(
             stripeCustomerId
-          )) ||
-          (await stripeService.hasProcessingPaymentIntent(stripeCustomerId))
+          )
         ) {
           this.setStatus(409)
           return {


### PR DESCRIPTION
Removed `hasProcessingPaymentIntent` from StripeService.ts 

Removed corresponding check in the endpoint.

Closes #287 