### PR TITLE
copy templates to build outputs

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -41,7 +41,8 @@
   "scripts": {
     "start": "concurrently \"yarn nodemon -e ts,js --exec \" \"yarn tsoa spec-and-routes && yarn normalise-newlines && yarn workspace client generate-types\"",
     "nodemon": "nodemon",
-    "build": "tsc -p ./tsconfig.prod.json && tsc-alias",
+    "build": "tsc -p ./tsconfig.prod.json && tsc-alias && yarn copy-templates",
+    "copy-templates": "cp -r ./src/business-layer/templates ./dist/business-layer/templates",
     "serve": "node --es-module-specifier-resolution=node dist/index.js",
     "token": "ts-node ./tooling/login-prod.ts",
     "timestamp": "ts-node ./tooling/timestamp-conversion.ts",

--- a/server/src/business-layer/services/MailService.ts
+++ b/server/src/business-layer/services/MailService.ts
@@ -4,6 +4,10 @@ import { compileFile } from "pug"
 
 const TEMPLATE_BASE_PATH = path.join(__dirname, "..", "templates")
 
+const BOOKING_CONFIRMATION_TEMPLATE = compileFile(
+  `${TEMPLATE_BASE_PATH}/BookingConfirmation.pug`
+)
+
 const transporter = NodeMailer.createTransport({
   service: "Gmail",
   host: "smtp.gmail.com",
@@ -30,15 +34,11 @@ export default class MailService {
     startDateString: string,
     endDateString: string
   ) {
-    const compiledFunction = compileFile(
-      `${TEMPLATE_BASE_PATH}/BookingConfirmation.pug`
-    )
-
     const info = await transporter.sendMail({
       from: '"UASC Bookings"',
       to: recipientEmail,
       subject: `Your booking from ${startDateString} to ${endDateString}`,
-      html: compiledFunction({
+      html: BOOKING_CONFIRMATION_TEMPLATE({
         name: recipientName,
         startDate: startDateString,
         endDate: endDateString

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,7 +16,6 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true
   },
-
   "include": [
     "tooling/**/*",
     "src/**/*",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,6 +16,7 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true
   },
+
   "include": [
     "tooling/**/*",
     "src/**/*",


### PR DESCRIPTION
Right now the backend fails to use the template because it can't compile

Also made the compile function last the app lifetime, do not need to be constantly recompiling.