### PR TITLE
fix booking creation if user already has a booking

### DIFF
--- a/server/src/middleware/tests/BookingController.test.ts
+++ b/server/src/middleware/tests/BookingController.test.ts
@@ -441,7 +441,7 @@ describe("BookingController endpoint tests", () => {
         ).length
       ).toEqual(1)
 
-      const newEndDate = dateToFirestoreTimeStamp(new Date("12/31/2023"))
+      const newEndDate = dateToFirestoreTimeStamp(new Date("01/01/2024"))
 
       res = await request
         .post("/bookings/create-bookings")

--- a/server/src/middleware/tests/BookingController.test.ts
+++ b/server/src/middleware/tests/BookingController.test.ts
@@ -402,13 +402,18 @@ describe("BookingController endpoint tests", () => {
         max_bookings: 10
       })
 
+      await bookingSlotService.createBookingSlot({
+        date: dateToFirestoreTimeStamp(new Date("01/01/2024")),
+        max_bookings: 10
+      })
+
       await bookingDataService.createBooking({
         user_id: MEMBER_USER_UID,
         booking_slot_id: slot1.id,
         stripe_payment_id: ""
       })
 
-      const res = await request
+      let res = await request
         .post("/bookings/create-bookings")
         .set("Authorization", `Bearer ${adminToken}`)
         .send({
@@ -426,6 +431,35 @@ describe("BookingController endpoint tests", () => {
           ])
         })
       ])
+
+      expect(
+        (
+          await bookingSlotService.getBookingSlotsBetweenDateRange(
+            startDate,
+            endDate
+          )
+        ).length
+      ).toEqual(1)
+
+      const newEndDate = dateToFirestoreTimeStamp(new Date("12/31/2023"))
+
+      res = await request
+        .post("/bookings/create-bookings")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({
+          startDate,
+          newEndDate,
+          userIds: [MEMBER_USER_UID]
+        })
+
+      expect(
+        (
+          await bookingSlotService.getBookingSlotsBetweenDateRange(
+            startDate,
+            newEndDate
+          )
+        ).length
+      ).toEqual(2)
     })
   })
 })

--- a/server/src/service-layer/controllers/BookingController.ts
+++ b/server/src/service-layer/controllers/BookingController.ts
@@ -78,8 +78,12 @@ export class BookingController extends Controller {
         let userIds = [...requestBody.userIds]
         /** For every slotid add a booking for that id only if user doesn't already have a booking */
         const userIdsPromises = userIds.map(async (userId) => {
+          const existingBookingsForUser =
+            await bookingDataService.getBookingsByUserId(userId)
           if (
-            (await bookingDataService.getBookingsByUserId(userId)).length !== 0
+            existingBookingsForUser.some(
+              (booking) => booking.booking_slot_id === slot.id
+            )
           ) {
             userIds = userIds.filter((id) => id !== userId) // Remove user from list if they already have a booking
           } else {


### PR DESCRIPTION
before the check meant that users couldn't be added if they had a booking, but that was not specific to the range.