### PR TITLE
remove hard redirect on admin pages to improve UX

### DIFF
--- a/client/src/app/admin/layout.tsx
+++ b/client/src/app/admin/layout.tsx
@@ -5,17 +5,14 @@ import AdminNavbar from "@/components/composite/Admin/AdminNavbar/AdminNavbar"
 import { useAppData } from "@/store/Store"
 import { AdminBookingViewProvider } from "@/components/composite/Admin/AdminBookingView/AdminBookingViewContext"
 import { ReactNode } from "react"
-import { useRouter } from "next/navigation"
 import { QueryClientProvider } from "@tanstack/react-query"
 import queryClient from "@/services/QueryClient"
 import Loader from "@/components/generic/SuspenseComponent/Loader"
 
 const AdminLayout = ({ children }: Readonly<{ children: ReactNode }>) => {
   const [{ currentUserClaims }] = useAppData()
-  const router = useRouter()
 
   if (!currentUserClaims?.admin) {
-    router.push("/")
     return <Loader />
   }
 


### PR DESCRIPTION
Right now the redirects does not play nicely with SSG, as the auth state seems to reset when the page is lazy-loaded.

We assume the only people accessing this route are admins, and if its is not, then an infinite loader is an acceptable experience.