### PR TITLE
add the lodge info schema to sanity

### DIFF
--- a/client/sanity.config.ts
+++ b/client/sanity.config.ts
@@ -42,6 +42,15 @@ export default defineConfig({
               S.document().schemaType("home-page").documentId("home-page")
             ),
 
+            S.listItem()
+              .title("Lodge Information")
+              .id("lodge-information")
+              .child(
+                S.document()
+                  .schemaType("lodge-information")
+                  .documentId("lodge-information")
+              ),
+
             // Regular document types
             S.documentTypeListItem("about-item").title("About Item"),
             S.documentTypeListItem("contact-detail").title("Contact Detail")

--- a/client/sanity/schema.ts
+++ b/client/sanity/schema.ts
@@ -1,8 +1,9 @@
 import { AboutItemSchema } from "@/models/sanity/AboutItem/Schema"
 import { ContactDetailSchema } from "@/models/sanity/ContactDetail/Schema"
 import { HomePageSchema } from "@/models/sanity/HomePage/Schema"
+import { LodgeInfoSchema } from "@/models/sanity/LodgeInfo/Schema"
 import { type SchemaTypeDefinition } from "sanity"
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [AboutItemSchema, HomePageSchema, ContactDetailSchema]
+  types: [AboutItemSchema, HomePageSchema, ContactDetailSchema, LodgeInfoSchema]
 }

--- a/client/src/models/sanity/LodgeInfo/Schema.ts
+++ b/client/src/models/sanity/LodgeInfo/Schema.ts
@@ -1,0 +1,22 @@
+import { SchemaTypeDefinition, defineField } from "sanity"
+
+export const LodgeInfoSchema: SchemaTypeDefinition = {
+  name: "lodge-information",
+  title: "Lodge Information",
+  description: "What to display to the user before they enter the booking view",
+  type: "document",
+  fields: [
+    defineField({
+      name: "information",
+      description: "An overview of what the user gets out of booking the lodge",
+      type: "array",
+      of: [{ type: "block" }]
+    }),
+    defineField({
+      name: "images",
+      description: "Images used to promote the lodge",
+      type: "array",
+      of: [{ type: "image" }]
+    })
+  ]
+}

--- a/client/src/models/sanity/LodgeInfo/Utils.ts
+++ b/client/src/models/sanity/LodgeInfo/Utils.ts
@@ -1,0 +1,2 @@
+export const LODGE_INFORMATION_GROQ_QUERY =
+  `[_type == "lodge-information"]` as const


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c2be42d3-893f-41da-8c0f-9ed42d24a9a9)

We will have to create a renderer for rich text blocks, likely involving one of the following:

- https://github.com/sanity-io/block-content-to-react/issues/26
- https://github.com/portabletext/react-portabletext