### PR TITLE
Convert sanity images to webp in attempt to improve page loads

### DIFF
--- a/client/sanity/lib/utils.ts
+++ b/client/sanity/lib/utils.ts
@@ -21,3 +21,11 @@ export const sanityQuery = async <T>(query: string) => {
 
   return ((await res.json()) as { result: any }).result as T
 }
+
+/**
+ * @param url the original sanity image URL **without** any query params attached
+ *
+ * @returns a image `src` with the `format=auto` query appended
+ */
+export const autoFormatSanityImageSrc = (url: string) =>
+  `${url}?format=auto` as const

--- a/client/sanity/lib/utils.ts
+++ b/client/sanity/lib/utils.ts
@@ -28,4 +28,4 @@ export const sanityQuery = async <T>(query: string) => {
  * @returns a image `src` with the `format=auto` query appended
  */
 export const autoFormatSanityImageSrc = (url: string) =>
-  `${url}?format=auto` as const
+  `${url}?auto=format` as const

--- a/client/sanity/lib/utils.ts
+++ b/client/sanity/lib/utils.ts
@@ -27,5 +27,8 @@ export const sanityQuery = async <T>(query: string) => {
  *
  * @returns a image `src` with the `format=auto` query appended
  */
-export const autoFormatSanityImageSrc = (url: string) =>
-  `${url}?auto=format` as const
+export const autoFormatSanityImageSrc = (url: string) => {
+  const newUrl = new URL(url)
+  newUrl.searchParams.append("auto", "format")
+  return newUrl.toString()
+}

--- a/client/sanity/lib/utils.ts
+++ b/client/sanity/lib/utils.ts
@@ -23,12 +23,60 @@ export const sanityQuery = async <T>(query: string) => {
 }
 
 /**
- * @param url the original sanity image URL **without** any query params attached
- *
- * @returns a image `src` with the `format=auto` query appended
+ * Class representing a URL for a Sanity image with various utility methods
+ * to manipulate the URL by appending query parameters.
  */
-export const autoFormatSanityImageSrc = (url: string) => {
-  const newUrl = new URL(url)
-  newUrl.searchParams.append("auto", "format")
-  return newUrl.toString()
+export class SanityImageUrl {
+  private url: URL
+
+  /**
+   * Creates an instance of SanityImageUrl.
+   *
+   * @param url - The original Sanity image URL **without** any query parameters attached.
+   * @throws {TypeError} If the provided URL is invalid.
+   */
+  constructor(url: string) {
+    this.url = new URL(url)
+  }
+
+  /**
+   * Appends the `auto=format` query parameter to the URL.
+   *
+   * This is used to [get the image in webp form](https://www.sanity.io/answers/optimizing-image-file-sizes-in-studio-and-using-url-parameters-for-width-and-format-)
+   *
+   * **Note:** This method **must** only be called once.
+   */
+  public autoFormat() {
+    this.url.searchParams.append("auto", "format")
+    return this
+  }
+
+  /**
+   * Appends the height query parameter to the URL.
+   *
+   * @param h - The height in pixels to set the image to.
+   */
+  public height(h: number) {
+    this.url.searchParams.append("h", h.toString())
+    return this
+  }
+
+  /**
+   * Appends the height query parameter to the URL.
+   *
+   * @param h - The height in pixels to set the image to.
+   */
+  public width(w: number) {
+    this.url.searchParams.append("w", w.toString())
+    return this
+  }
+
+  /**
+   * Returns the string representation of the URL, including any modifications made.
+   *
+   * @returns {string} The modified URL as a string.
+   */
+  public toString(): string {
+    return this.url.toString()
+  }
 }

--- a/client/src/app/about/page.tsx
+++ b/client/src/app/about/page.tsx
@@ -6,10 +6,7 @@ import {
   ABOUT_ITEMS_GROQ_QUERY,
   AboutItem
 } from "@/models/sanity/AboutItem/Utils"
-import {
-  autoFormatSanityImageSrc,
-  sanityQuery
-} from "../../../sanity/lib/utils"
+import { SanityImageUrl, sanityQuery } from "../../../sanity/lib/utils"
 import {
   COMMITTEE_MEMBERS_GROQ_QUERY,
   CommitteeMembers
@@ -49,7 +46,12 @@ const About = async () => {
                   text={item.description || ""}
                   variant={side}
                   imageSrc={
-                    item.imageUrl ? autoFormatSanityImageSrc(item.imageUrl) : ""
+                    item.imageUrl
+                      ? new SanityImageUrl(item.imageUrl)
+                          .autoFormat()
+                          .width(1000)
+                          .toString()
+                      : ""
                   }
                 />
                 {
@@ -73,7 +75,10 @@ const About = async () => {
                 <ExecImage
                   src={
                     member.imageUrl
-                      ? autoFormatSanityImageSrc(member.imageUrl)
+                      ? new SanityImageUrl(member.imageUrl)
+                          .autoFormat()
+                          .width(300)
+                          .toString()
                       : ""
                   }
                   alt={member.name || ""}

--- a/client/src/app/about/page.tsx
+++ b/client/src/app/about/page.tsx
@@ -6,7 +6,10 @@ import {
   ABOUT_ITEMS_GROQ_QUERY,
   AboutItem
 } from "@/models/sanity/AboutItem/Utils"
-import { sanityQuery } from "../../../sanity/lib/utils"
+import {
+  autoFormatSanityImageSrc,
+  sanityQuery
+} from "../../../sanity/lib/utils"
 import {
   COMMITTEE_MEMBERS_GROQ_QUERY,
   CommitteeMembers
@@ -45,7 +48,9 @@ const About = async () => {
                   title={item.title || ""}
                   text={item.description || ""}
                   variant={side}
-                  imageSrc={item.imageUrl || ""}
+                  imageSrc={
+                    item.imageUrl ? autoFormatSanityImageSrc(item.imageUrl) : ""
+                  }
                 />
                 {
                   // Don't need divider for last row
@@ -66,7 +71,11 @@ const About = async () => {
                 className="flex-shrink-1 group relative mb-4 flex w-1/3 items-center justify-center overflow-hidden px-2 sm:w-1/4 md:w-1/5 lg:w-1/6"
               >
                 <ExecImage
-                  src={member.imageUrl || ""}
+                  src={
+                    member.imageUrl
+                      ? autoFormatSanityImageSrc(member.imageUrl)
+                      : ""
+                  }
                   alt={member.name || ""}
                   title={member.title || ""}
                   name={member.name || ""}

--- a/client/src/app/sections/BenefitSection.tsx
+++ b/client/src/app/sections/BenefitSection.tsx
@@ -2,7 +2,7 @@ import { Benefit } from "@/components/utils/types"
 import Image from "next/image"
 import HomeSectionHeading from "./utils/HomeSectionHeading"
 import HomeSectionWrapper from "./utils/HomeSectionWrapper"
-import { autoFormatSanityImageSrc } from "../../../sanity/lib/utils"
+import { SanityImageUrl } from "../../../sanity/lib/utils"
 
 interface IBenefitSection {
   benefits: Benefit[]
@@ -18,7 +18,14 @@ const BenefitSection = ({ benefits }: IBenefitSection) => (
           return (
             <div key={text} className="relative isolate h-64 w-full">
               <Image
-                src={image ? autoFormatSanityImageSrc(image) : ""}
+                src={
+                  image
+                    ? new SanityImageUrl(image)
+                        .autoFormat()
+                        .width(1000)
+                        .toString()
+                    : ""
+                }
                 alt={text}
                 fill
                 className="-z-10 size-full object-cover"

--- a/client/src/app/sections/BenefitSection.tsx
+++ b/client/src/app/sections/BenefitSection.tsx
@@ -2,6 +2,7 @@ import { Benefit } from "@/components/utils/types"
 import Image from "next/image"
 import HomeSectionHeading from "./utils/HomeSectionHeading"
 import HomeSectionWrapper from "./utils/HomeSectionWrapper"
+import { autoFormatSanityImageSrc } from "../../../sanity/lib/utils"
 
 interface IBenefitSection {
   benefits: Benefit[]
@@ -17,7 +18,7 @@ const BenefitSection = ({ benefits }: IBenefitSection) => (
           return (
             <div key={text} className="relative isolate h-64 w-full">
               <Image
-                src={image || ""}
+                src={image ? autoFormatSanityImageSrc(image) : ""}
                 alt={text}
                 fill
                 className="-z-10 size-full object-cover"


### PR DESCRIPTION
https://www.sanity.io/answers/optimizing-image-file-sizes-in-studio-and-using-url-parameters-for-width-and-format-

created server compatible class called `SanityImageUrl` in `client/sanity/lib/utils.ts` to allow for basic manipulation of the image urls.