### PR TITLE
Restyle lodge booking page to be more robust

### DIFF
--- a/client/src/app/bookings/page.tsx
+++ b/client/src/app/bookings/page.tsx
@@ -40,7 +40,7 @@ const BookingPage = async () => {
         enableNetworkRequests
         lodgeInfoProps={{
           children: <RenderedContent />,
-          images: processedImages
+          imageSrcs: processedImages
         }}
       />
     </>

--- a/client/src/components/composite/LodgeInfo/LodgeInfo.story.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfo.story.tsx
@@ -21,6 +21,10 @@ export const Default: Story = {
     children: (
       <>
         <div className="flex flex-col gap-4">
+          <h2>
+            Visit for the Whakapapa Ski field status, lift, food and retail
+            status and status of other activities.
+          </h2>
           <p>
             The UASC Lodge is located in the Whakapapa Ski field and is just a
             3-5 min walk from the bottom of the Sky Waka Gondola, meaning you

--- a/client/src/components/composite/LodgeInfo/LodgeInfo.story.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfo.story.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof LodgeInfo>
 export const Default: Story = {
   args: {
     handleBookLodgeClick: () => console.log(""),
-    images: [
+    imageSrcs: [
       "https://via.placeholder.com/400x400?text=Image+1",
       "https://via.placeholder.com/400x400?text=I+SUPPORT+LGBT",
       "https://via.placeholder.com/400x400?text=Image+3",

--- a/client/src/components/composite/LodgeInfo/LodgeInfo.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfo.tsx
@@ -23,19 +23,20 @@ const LodgeInfo = ({ children, images, handleBookLodgeClick }: ILodgeInfo) => {
     <div className="flex w-full flex-col gap-2">
       <div className="flex justify-center pt-3">
         <Button variant="default" onClick={handleBookLodgeClick}>
-          Book The Lodge
+          Skip Information
         </Button>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div>
-          <LodgeInfoGallery images={images || []}></LodgeInfoGallery>
-        </div>
+      <div className="grid grid-cols-1 gap-4">
         <div>
           <LodgeInfoComponent
             handleBookLodgeClick={() => handleBookLodgeClick?.()}
           >
             {children}
           </LodgeInfoComponent>
+        </div>
+
+        <div>
+          <LodgeInfoGallery imageUrls={images || []}></LodgeInfoGallery>
         </div>
       </div>
     </div>

--- a/client/src/components/composite/LodgeInfo/LodgeInfo.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfo.tsx
@@ -11,14 +11,18 @@ export interface ILodgeInfo {
   /**
    * List of image srcs
    */
-  images?: string[]
+  imageSrcs?: string[]
   /**
    * Handler to be called once the user clicks the call to action
    */
   handleBookLodgeClick?: () => void
 }
 
-const LodgeInfo = ({ children, images, handleBookLodgeClick }: ILodgeInfo) => {
+const LodgeInfo = ({
+  children,
+  imageSrcs,
+  handleBookLodgeClick
+}: ILodgeInfo) => {
   return (
     <div className="flex w-full flex-col gap-2">
       <div className="flex justify-center pt-3">
@@ -36,7 +40,7 @@ const LodgeInfo = ({ children, images, handleBookLodgeClick }: ILodgeInfo) => {
         </div>
 
         <div>
-          <LodgeInfoGallery imageUrls={images || []}></LodgeInfoGallery>
+          <LodgeInfoGallery imageSrcs={imageSrcs || []}></LodgeInfoGallery>
         </div>
       </div>
     </div>

--- a/client/src/components/composite/LodgeInfo/LodgeInfo.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfo.tsx
@@ -1,3 +1,4 @@
+import Button from "@/components/generic/FigmaButtons/FigmaButton"
 import LodgeInfoComponent from "./LodgeInfoComponent/LodgeInfoComponent"
 import LodgeInfoGallery from "./LodgeInfoGallery/LodgeInfoGallery"
 import { ReactNode } from "react"
@@ -19,16 +20,23 @@ export interface ILodgeInfo {
 
 const LodgeInfo = ({ children, images, handleBookLodgeClick }: ILodgeInfo) => {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <div>
-        <LodgeInfoGallery images={images || []}></LodgeInfoGallery>
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex justify-center pt-3">
+        <Button variant="default" onClick={handleBookLodgeClick}>
+          Book The Lodge
+        </Button>
       </div>
-      <div>
-        <LodgeInfoComponent
-          handleBookLodgeClick={() => handleBookLodgeClick?.()}
-        >
-          {children}
-        </LodgeInfoComponent>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <LodgeInfoGallery images={images || []}></LodgeInfoGallery>
+        </div>
+        <div>
+          <LodgeInfoComponent
+            handleBookLodgeClick={() => handleBookLodgeClick?.()}
+          >
+            {children}
+          </LodgeInfoComponent>
+        </div>
       </div>
     </div>
   )

--- a/client/src/components/composite/LodgeInfo/LodgeInfo.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfo.tsx
@@ -18,6 +18,12 @@ export interface ILodgeInfo {
   handleBookLodgeClick?: () => void
 }
 
+/**
+ * Component displaying information about the lodge before the user makes a booking
+ *
+ * Use case - if someone new to the club wants to know what the lodge is, or are unsure about
+ * how to prepare/find more information
+ */
 const LodgeInfo = ({
   children,
   imageSrcs,

--- a/client/src/components/composite/LodgeInfo/LodgeInfoComponent/LodgeInfoComponent.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoComponent/LodgeInfoComponent.tsx
@@ -2,17 +2,35 @@ import Button from "@/components/generic/FigmaButtons/FigmaButton"
 import { ReactNode } from "react"
 
 interface ILodgeInfoComponent {
+  /**
+   * The **pre-rendered** children that should be displayed in the the container
+   * (This should generally be text content)
+   */
   children: ReactNode
+  /**
+   * Handler to be called when call to action button is clicked
+   *
+   * @example
+   * () => navigateToActualBookLodgeScreen()
+   */
   handleBookLodgeClick: () => void
 }
 
-const LodgeInfoComponent = ({ children }: ILodgeInfoComponent) => {
+/**
+ * @deprecated do not consume directly on page, use `LodgeInfo` instead
+ */
+const LodgeInfoComponent = ({
+  children,
+  handleBookLodgeClick
+}: ILodgeInfoComponent) => {
   return (
-    <div className="border-gray-3 flex h-full w-full flex-col justify-center rounded border bg-white px-2 py-12 pb-8 sm:px-6">
-      <div className="text-dark-blue-100 flex flex-col gap-4 lg:justify-center">
+    <div className="border-gray-3 flex h-full w-full flex-col justify-center rounded border bg-white px-2 py-12 pb-8 sm:px-3">
+      <div className="text-dark-blue-100 mb-3 flex flex-col gap-4 lg:justify-center">
         {children}
       </div>
-      <Button variant="inverted-default-sm">Book the lodge</Button>
+      <Button variant="inverted-default-sm" onClick={handleBookLodgeClick}>
+        Book the lodge
+      </Button>
     </div>
   )
 }

--- a/client/src/components/composite/LodgeInfo/LodgeInfoComponent/LodgeInfoComponent.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoComponent/LodgeInfoComponent.tsx
@@ -6,21 +6,13 @@ interface ILodgeInfoComponent {
   handleBookLodgeClick: () => void
 }
 
-const LodgeInfoComponent = ({
-  children,
-  handleBookLodgeClick
-}: ILodgeInfoComponent) => {
+const LodgeInfoComponent = ({ children }: ILodgeInfoComponent) => {
   return (
     <div className="border-gray-3 flex h-full w-full flex-col justify-center rounded border bg-white px-2 py-12 pb-8 sm:px-6">
       <div className="text-dark-blue-100 flex flex-col gap-4 lg:justify-center">
         {children}
-
-        <div className="flex justify-center pt-3">
-          <Button variant="default-sm" onClick={handleBookLodgeClick}>
-            Book The Lodge
-          </Button>
-        </div>
       </div>
+      <Button variant="inverted-default-sm">Book the lodge</Button>
     </div>
   )
 }

--- a/client/src/components/composite/LodgeInfo/LodgeInfoComponent/LodgeInfoComponent.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoComponent/LodgeInfoComponent.tsx
@@ -11,7 +11,7 @@ const LodgeInfoComponent = ({
   handleBookLodgeClick
 }: ILodgeInfoComponent) => {
   return (
-    <div className="border-gray-3 flex h-full w-full flex-col justify-center rounded border bg-white px-6 py-12 pb-8">
+    <div className="border-gray-3 flex h-full w-full flex-col justify-center rounded border bg-white px-2 py-12 pb-8 sm:px-6">
       <div className="text-dark-blue-100 flex flex-col gap-4 lg:justify-center">
         {children}
 

--- a/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.story.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.story.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof LodgeInfoGallery>
 
 export const Default: Story = {
   args: {
-    imageUrls: [
+    imageSrcs: [
       "https://via.placeholder.com/400x400?text=Image+1",
       "https://via.placeholder.com/400x400?text=Image+2",
       "https://via.placeholder.com/400x400?text=Image+3",
@@ -23,14 +23,14 @@ export const Default: Story = {
 
 export const SingleImage: Story = {
   args: {
-    imageUrls: ["https://via.placeholder.com/400x400?text=Single+Image"]
+    imageSrcs: ["https://via.placeholder.com/400x400?text=Single+Image"]
   },
   tags: ["autodocs"]
 }
 
 export const NoImages: Story = {
   args: {
-    imageUrls: []
+    imageSrcs: []
   },
   tags: ["autodocs"]
 }

--- a/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.story.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.story.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof LodgeInfoGallery>
 
 export const Default: Story = {
   args: {
-    images: [
+    imageUrls: [
       "https://via.placeholder.com/400x400?text=Image+1",
       "https://via.placeholder.com/400x400?text=Image+2",
       "https://via.placeholder.com/400x400?text=Image+3",
@@ -23,14 +23,14 @@ export const Default: Story = {
 
 export const SingleImage: Story = {
   args: {
-    images: ["https://via.placeholder.com/400x400?text=Single+Image"]
+    imageUrls: ["https://via.placeholder.com/400x400?text=Single+Image"]
   },
   tags: ["autodocs"]
 }
 
 export const NoImages: Story = {
   args: {
-    images: []
+    imageUrls: []
   },
   tags: ["autodocs"]
 }

--- a/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.tsx
@@ -9,17 +9,17 @@ interface ILodgeInfoGallery {
    * @example
    * ['https://image-url-1.com', 'https://image-url-2.com', 'https://image-url-3.com']
    */
-  imageUrls: string[]
+  imageSrcs: string[]
 }
 
 /**
  * Simple photo gallery that displays images in a single row (can be scrolled horizontally)
  */
-const LodgeInfoGallery = ({ imageUrls = [] }: ILodgeInfoGallery) => {
+const LodgeInfoGallery = ({ imageSrcs = [] }: ILodgeInfoGallery) => {
   return (
     <>
       <div className="flex space-x-4 overflow-x-auto p-2">
-        {imageUrls.map((url, index) => (
+        {imageSrcs.map((url, index) => (
           <div key={index} className="flex-shrink-0">
             <Image
               src={url}

--- a/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.tsx
@@ -1,57 +1,26 @@
-import { useState, FC } from "react"
 import Image from "next/image"
-import RightArrow from "@/assets/icons/whitearrowright.svg"
-import LeftArrow from "@/assets/icons/whitearrowleft.svg"
 
-interface LodgeInfoGalleryProps {
-  images: string[]
+interface ILodgeInfoGallery {
+  imageUrls: string[]
 }
 
-const LodgeInfoGallery: FC<LodgeInfoGalleryProps> = ({ images }) => {
-  const [currentIndex, setCurrentIndex] = useState(0)
-
-  const handlePreviousClick = () => {
-    setCurrentIndex((prevIndex) =>
-      prevIndex === 0 ? images.length - 1 : prevIndex - 1
-    )
-  }
-
-  const handleNextClick = () => {
-    setCurrentIndex((prevIndex) =>
-      prevIndex === images.length - 1 ? 0 : prevIndex + 1
-    )
-  }
-
+const LodgeInfoGallery = ({ imageUrls = [] }: ILodgeInfoGallery) => {
   return (
-    <div className="relative flex items-center justify-center overflow-hidden">
-      {images.length > 0 ? (
-        <Image
-          src={images[currentIndex]}
-          alt={`Lodge image ${currentIndex + 1}`}
-          width={500}
-          height={500}
-          objectFit="contain"
-          className="rounded-lg"
-        />
-      ) : (
-        <p>No images available</p>
-      )}
-      <button
-        onClick={handlePreviousClick}
-        className="absolute left-4 top-1/2 z-10 -translate-y-1/2 transform opacity-70 hover:opacity-100"
-        aria-label="Previous image"
-      >
-        <LeftArrow />
-      </button>
-
-      <button
-        onClick={handleNextClick}
-        className="absolute right-4 top-1/2 z-10 -translate-y-1/2 transform opacity-70 hover:opacity-100"
-        aria-label="Next image"
-      >
-        <RightArrow />
-      </button>
-    </div>
+    <>
+      <div className="flex justify-center space-x-4 overflow-x-auto p-4">
+        {imageUrls.map((url, index) => (
+          <div key={index} className="flex-shrink-0">
+            <Image
+              src={url}
+              alt={`Photo ${index + 1}`}
+              width={400}
+              height={400}
+              className="rounded-sm shadow-lg"
+            />
+          </div>
+        ))}
+      </div>
+    </>
   )
 }
 

--- a/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.tsx
@@ -1,13 +1,24 @@
 import Image from "next/image"
 
 interface ILodgeInfoGallery {
+  /**
+   * A list of srcs for all the images in the gallery.
+   *
+   * This should be pre-sorted
+   *
+   * @example
+   * ['https://image-url-1.com', 'https://image-url-2.com', 'https://image-url-3.com']
+   */
   imageUrls: string[]
 }
 
+/**
+ * Simple photo gallery that displays images in a single row (can be scrolled horizontally)
+ */
 const LodgeInfoGallery = ({ imageUrls = [] }: ILodgeInfoGallery) => {
   return (
     <>
-      <div className="flex justify-center space-x-4 overflow-x-auto p-4">
+      <div className="flex space-x-4 overflow-x-auto p-2">
         {imageUrls.map((url, index) => (
           <div key={index} className="flex-shrink-0">
             <Image

--- a/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.tsx
+++ b/client/src/components/composite/LodgeInfo/LodgeInfoGallery/LodgeInfoGallery.tsx
@@ -4,7 +4,7 @@ interface ILodgeInfoGallery {
   /**
    * A list of srcs for all the images in the gallery.
    *
-   * This should be pre-sorted
+   * This should be **pre-sorted** and **unique**
    *
    * @example
    * ['https://image-url-1.com', 'https://image-url-2.com', 'https://image-url-3.com']
@@ -20,15 +20,18 @@ const LodgeInfoGallery = ({ imageSrcs = [] }: ILodgeInfoGallery) => {
     <>
       <div className="flex space-x-4 overflow-x-auto p-2">
         {imageSrcs.map((url, index) => (
-          <div key={index} className="flex-shrink-0">
-            <Image
-              src={url}
-              alt={`Photo ${index + 1}`}
-              width={400}
-              height={400}
-              className="rounded-sm shadow-lg"
-            />
-          </div>
+          <>
+            {/* We require a `max-width` style to constrain the image on smaller screens */}
+            <div key={url} className="max-w-[95vw] flex-shrink-0">
+              <Image
+                src={url}
+                alt={`Photo ${index + 1}`}
+                width={400}
+                height={400}
+                className="rounded-sm shadow-lg"
+              />
+            </div>
+          </>
         ))}
       </div>
     </>


### PR DESCRIPTION
Right now the problem with the current one is that it does not play well on smaller screens, and the photo gallery is pretty hard to use. To solve this it makes more sense to keep styling simpler.

- Simplified gallery to just horizontally scroll
- Only use one column
- Add button to skip the lodge information