### PR TITLE
backend create endpoint for admin to create event and also to fetch all events

### DIFF
--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -52,6 +52,9 @@ export interface paths {
     /** @description Signs up for an event */
     post: operations["EventSignup"];
   };
+  "/events": {
+    get: operations["GetAllEvents"];
+  };
   "/bookings": {
     /** @description Fetches all bookings for a user based on their UID. */
     get: operations["GetAllBookings"];
@@ -139,6 +142,10 @@ export interface paths {
   "/admin/bookings/history": {
     /** @description Fetches the **latest** booking history events (uses cursor-based pagination) */
     get: operations["GetLatestHistory"];
+  };
+  "/admin/events/create": {
+    /** @description Endpoint for admin to create a new event */
+    post: operations["CreateNewEvent"];
   };
 }
 
@@ -296,6 +303,48 @@ export interface components {
     EventSignupBody: {
       event_id: string;
       reservation: components["schemas"]["EventReservation"];
+    };
+    Event: {
+      /** @description The title of this event */
+      title: string;
+      /**
+       * @description An optional description for this event
+       * This should be in markdown
+       */
+      description?: string;
+      /** @description The link for the image to display on the event page (essentially a thumbnail) */
+      image_url?: string;
+      /** @description The location of this event */
+      location: string;
+      /**
+       * @description The start date of the event.
+       * Note that this date is in UTC time.
+       * Use the same start and end day to show that its a 1 day event.
+       */
+      start_date: components["schemas"]["FirebaseFirestore.Timestamp"];
+      /**
+       * @description The end date of the event.
+       * Note that this date is in UTC time.
+       */
+      end_date: components["schemas"]["FirebaseFirestore.Timestamp"];
+      /**
+       * Format: double
+       * @description Max number of attendees at this event, left as optional for uncapped
+       * @example 30
+       */
+      max_occupancy?: number;
+    };
+    GetAllEventsResponse: {
+      error?: string;
+      message?: string;
+      /**
+       * @description Needed for firestore operations which do not support offset
+       * based pagination
+       *
+       * **Will be undefined in case of last page**
+       */
+      nextCursor?: string;
+      data?: components["schemas"]["Event"][];
     };
     AllUserBookingSlotsResponse: {
       error?: string;
@@ -621,6 +670,9 @@ export interface components {
       message?: string;
       historyEvents?: components["schemas"]["BookingHistoryEvent"][];
     };
+    CreateEventBody: {
+      data: components["schemas"]["Event"];
+    };
   };
   responses: {
   };
@@ -814,6 +866,22 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["EventSignupResponse"];
+        };
+      };
+    };
+  };
+  GetAllEvents: {
+    parameters: {
+      query?: {
+        limit?: number;
+        cursor?: string;
+      };
+    };
+    responses: {
+      /** @description Successfully fetched all events */
+      200: {
+        content: {
+          "application/json": components["schemas"]["GetAllEventsResponse"];
         };
       };
     };
@@ -1089,6 +1157,20 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["FetchLatestBookingHistoryEventResponse"];
         };
+      };
+    };
+  };
+  /** @description Endpoint for admin to create a new event */
+  CreateNewEvent: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateEventBody"];
+      };
+    };
+    responses: {
+      /** @description Created Event */
+      201: {
+        content: never;
       };
     };
   };

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -327,6 +327,10 @@ export interface components {
        * Note that this date is in UTC time.
        */
       end_date: components["schemas"]["FirebaseFirestore.Timestamp"];
+      /** @description Event start date for the event, **NOT** the signups, refer to {@link start_date} for signup start */
+      physical_start_date: components["schemas"]["FirebaseFirestore.Timestamp"];
+      /** @description Event end time for the event. **NOT** the signups, refer to {@link end_date} for signup end */
+      physical_end_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
        * Format: double
        * @description Max number of attendees at this event, left as optional for uncapped

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -158,7 +158,7 @@ export interface paths {
     /** @description Fetches the **latest** booking history events (uses cursor-based pagination) */
     get: operations["GetLatestHistory"];
   };
-  "/admin/events/create": {
+  "/admin/events": {
     /** @description Endpoint for admin to create a new event */
     post: operations["CreateNewEvent"];
   };

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -57,6 +57,10 @@ export interface paths {
     post: operations["EventSignup"];
   };
   "/events": {
+    /**
+     * @description Fetches latest events starting from the event with the latest starting date
+     * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+     */
     get: operations["GetAllEvents"];
   };
   "/events/reservations/stream": {
@@ -917,6 +921,10 @@ export interface operations {
       };
     };
   };
+  /**
+   * @description Fetches latest events starting from the event with the latest starting date
+   * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+   */
   GetAllEvents: {
     parameters: {
       query?: {

--- a/server/src/data-layer/models/firebase.ts
+++ b/server/src/data-layer/models/firebase.ts
@@ -184,12 +184,15 @@ export interface Event {
   end_date: Timestamp
 
   /**
-   * Event start date for the event, **NOT** the signups, refer to {@link start_date} for signup start
+   * Event start date for the event i.e the day members should meet at shads,
+   * **NOT** the signups, refer to {@link start_date} for signup start
    */
   physical_start_date: Timestamp
 
   /**
-   * Event end time for the event. **NOT** the signups, refer to {@link end_date} for signup end
+   * Event end time for the event i.e the last day members will be at the lodge,
+   * is optionial in case of one day events. **NOT** the signups, refer to
+   * {@link end_date} for signup end date
    */
   physical_end_date?: Timestamp
 

--- a/server/src/data-layer/models/firebase.ts
+++ b/server/src/data-layer/models/firebase.ts
@@ -176,11 +176,23 @@ export interface Event {
    * Use the same start and end day to show that its a 1 day event.
    */
   start_date: Timestamp
+
   /**
    * The end date of the event.
    * Note that this date is in UTC time.
    */
   end_date: Timestamp
+
+  /**
+   * Event start date for the event, **NOT** the signups, refer to {@link start_date} for signup start
+   */
+  physical_start_date: Timestamp
+
+  /**
+   * Event end time for the event. **NOT** the signups, refer to {@link end_date} for signup end
+   */
+  physical_end_date?: Timestamp
+
   /**
    * Max number of attendees at this event, left as optional for uncapped
    * @example 30

--- a/server/src/data-layer/services/BookingHistoryService.ts
+++ b/server/src/data-layer/services/BookingHistoryService.ts
@@ -86,6 +86,7 @@ class BookingHistoryService {
     PaginatedFirebaseResponse<DocumentDataWithUid<BookingHistoryEvent>>
   > {
     const res = await db.bookingHistory
+      // TODO: properly make this descending
       .orderBy("timestamp")
       .startAfter(startAfter || 0)
       .limit(limit)

--- a/server/src/data-layer/services/EventService.test.ts
+++ b/server/src/data-layer/services/EventService.test.ts
@@ -16,6 +16,7 @@ const event1: Event = {
   title: "UASC new event",
   description: "Grand opening of the website.",
   location: "Virtual pizza event",
+  physical_start_date: startDate,
   start_date: startDate,
   end_date: endDate
 }
@@ -23,6 +24,7 @@ const event2: Event = {
   title: "Snowboard racing",
   description: "Race and see who's the fastest!",
   location: "Snowsport club",
+  physical_start_date: startDate,
   start_date: startDate,
   end_date: endDate
 }

--- a/server/src/data-layer/services/EventService.ts
+++ b/server/src/data-layer/services/EventService.ts
@@ -140,7 +140,7 @@ class EventService {
   ) {
     let query = FirestoreCollections.events
       // Start at the largest (latest) date
-      .orderBy("start_date", "desc")
+      .orderBy("physical_start_date", "desc")
       .limit(limit)
 
     if (startAfter) {

--- a/server/src/data-layer/services/EventService.ts
+++ b/server/src/data-layer/services/EventService.ts
@@ -159,6 +159,11 @@ class EventService {
       .delete()
   }
 
+  /**
+   * Utility method for getting the snapshot of a document
+   *
+   * @param id the document id of the event to check, likely coming from a pagination cursor
+   */
   public async getEventSnapshot(id: string) {
     return await FirestoreCollections.events.doc(id).get()
   }

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -204,6 +204,8 @@ const models: TsoaRoute.Models = {
             "location": {"dataType":"string","required":true},
             "start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
             "end_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
+            "physical_start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
+            "physical_end_date": {"ref":"FirebaseFirestore.Timestamp"},
             "max_occupancy": {"dataType":"double"},
         },
         "additionalProperties": false,

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -195,6 +195,31 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Event": {
+        "dataType": "refObject",
+        "properties": {
+            "title": {"dataType":"string","required":true},
+            "description": {"dataType":"string"},
+            "image_url": {"dataType":"string"},
+            "location": {"dataType":"string","required":true},
+            "start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
+            "end_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
+            "max_occupancy": {"dataType":"double"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "GetAllEventsResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "error": {"dataType":"string"},
+            "message": {"dataType":"string"},
+            "nextCursor": {"dataType":"string"},
+            "data": {"dataType":"array","array":{"dataType":"refObject","ref":"Event"}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "AllUserBookingSlotsResponse": {
         "dataType": "refObject",
         "properties": {
@@ -517,6 +542,14 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "CreateEventBody": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"ref":"Event","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
 const templateService = new ExpressTemplateService(models, {"noImplicitAdditionalProperties":"throw-on-extras","bodyCoercion":true});
 
@@ -824,6 +857,37 @@ export function RegisterRoutes(app: Router) {
 
               templateService.apiHandler({
                 methodName: 'eventSignup',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/events',
+            ...(fetchMiddlewares<RequestHandler>(EventController)),
+            ...(fetchMiddlewares<RequestHandler>(EventController.prototype.getAllEvents)),
+
+            function EventController_getAllEvents(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    limit: {"default":20,"in":"query","name":"limit","dataType":"double"},
+                    cursor: {"in":"query","name":"cursor","dataType":"string"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new EventController();
+
+              templateService.apiHandler({
+                methodName: 'getAllEvents',
                 controller,
                 response,
                 next,
@@ -1326,6 +1390,37 @@ export function RegisterRoutes(app: Router) {
                 next,
                 validatedArgs,
                 successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/admin/events/create',
+            authenticateMiddleware([{"jwt":["admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminController.prototype.createNewEvent)),
+
+            function AdminController_createNewEvent(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    body: {"in":"body","name":"body","required":true,"ref":"CreateEventBody"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new AdminController();
+
+              templateService.apiHandler({
+                methodName: 'createNewEvent',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 201,
               });
             } catch (err) {
                 return next(err);

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -1471,7 +1471,7 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/admin/events/create',
+        app.post('/admin/events',
             authenticateMiddleware([{"jwt":["admin"]}]),
             ...(fetchMiddlewares<RequestHandler>(AdminController)),
             ...(fetchMiddlewares<RequestHandler>(AdminController.prototype.createNewEvent)),

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -420,6 +420,70 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"Event": {
+				"properties": {
+					"title": {
+						"type": "string",
+						"description": "The title of this event"
+					},
+					"description": {
+						"type": "string",
+						"description": "An optional description for this event\nThis should be in markdown"
+					},
+					"image_url": {
+						"type": "string",
+						"description": "The link for the image to display on the event page (essentially a thumbnail)"
+					},
+					"location": {
+						"type": "string",
+						"description": "The location of this event"
+					},
+					"start_date": {
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
+						"description": "The start date of the event.\nNote that this date is in UTC time.\nUse the same start and end day to show that its a 1 day event."
+					},
+					"end_date": {
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
+						"description": "The end date of the event.\nNote that this date is in UTC time."
+					},
+					"max_occupancy": {
+						"type": "number",
+						"format": "double",
+						"description": "Max number of attendees at this event, left as optional for uncapped",
+						"example": 30
+					}
+				},
+				"required": [
+					"title",
+					"location",
+					"start_date",
+					"end_date"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"GetAllEventsResponse": {
+				"properties": {
+					"error": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"nextCursor": {
+						"type": "string",
+						"description": "Needed for firestore operations which do not support offset\nbased pagination\n\n**Will be undefined in case of last page**"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/Event"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
 			"AllUserBookingSlotsResponse": {
 				"properties": {
 					"error": {
@@ -1277,6 +1341,18 @@
 				},
 				"type": "object",
 				"additionalProperties": false
+			},
+			"CreateEventBody": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/Event"
+					}
+				},
+				"required": [
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
 			}
 		},
 		"securitySchemes": {
@@ -1673,6 +1749,44 @@
 						}
 					}
 				}
+			}
+		},
+		"/events": {
+			"get": {
+				"operationId": "GetAllEvents",
+				"responses": {
+					"200": {
+						"description": "Successfully fetched all events",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/GetAllEventsResponse"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"default": 20,
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "cursor",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
 			}
 		},
 		"/bookings": {
@@ -2227,6 +2341,35 @@
 						}
 					}
 				]
+			}
+		},
+		"/admin/events/create": {
+			"post": {
+				"operationId": "CreateNewEvent",
+				"responses": {
+					"201": {
+						"description": "Created Event"
+					}
+				},
+				"description": "Endpoint for admin to create a new event",
+				"security": [
+					{
+						"jwt": [
+							"admin"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateEventBody"
+							}
+						}
+					}
+				}
 			}
 		}
 	},

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -1846,6 +1846,7 @@
 						}
 					}
 				},
+				"description": "Fetches latest events starting from the event with the latest starting date\n(**NOT** the signup open date) based on limit. Is paginated with a cursor",
 				"security": [],
 				"parameters": [
 					{

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -2441,7 +2441,7 @@
 				]
 			}
 		},
-		"/admin/events/create": {
+		"/admin/events": {
 			"post": {
 				"operationId": "CreateNewEvent",
 				"responses": {

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -446,6 +446,14 @@
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
 						"description": "The end date of the event.\nNote that this date is in UTC time."
 					},
+					"physical_start_date": {
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
+						"description": "Event start date for the event, **NOT** the signups, refer to {@link start_date} for signup start"
+					},
+					"physical_end_date": {
+						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
+						"description": "Event end time for the event. **NOT** the signups, refer to {@link end_date} for signup end"
+					},
 					"max_occupancy": {
 						"type": "number",
 						"format": "double",
@@ -457,7 +465,8 @@
 					"title",
 					"location",
 					"start_date",
-					"end_date"
+					"end_date",
+					"physical_start_date"
 				],
 				"type": "object",
 				"additionalProperties": false

--- a/server/src/middleware/tests/AdminController.test.ts
+++ b/server/src/middleware/tests/AdminController.test.ts
@@ -18,6 +18,8 @@ import BookingDataService from "data-layer/services/BookingDataService"
 import AuthService from "business-layer/services/AuthService"
 import { UserRecord } from "firebase-admin/auth"
 import BookingHistoryService from "data-layer/services/BookingHistoryService"
+import { Event } from "data-layer/models/firebase"
+import EventService from "data-layer/services/EventService"
 
 describe("AdminController endpoint tests", () => {
   describe("/admin/users", () => {
@@ -804,6 +806,27 @@ describe("AdminController endpoint tests", () => {
         .send({})
 
       expect(res.body.historyEvents).toHaveLength(2)
+    })
+  })
+
+  describe("/admin/events/create", () => {
+    const event1: Event = {
+      title: "UASC New event",
+      physical_start_date: dateToFirestoreTimeStamp(new Date()),
+      location: "UASC",
+      start_date: dateToFirestoreTimeStamp(new Date()),
+      end_date: dateToFirestoreTimeStamp(new Date())
+    }
+
+    it("should let admins create an event", async () => {
+      const res = await request
+        .post("/admin/events/create")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({ data: event1 })
+
+      expect(res.status).toEqual(201)
+
+      expect(await new EventService().getAllEvents(1)).toHaveLength(1)
     })
   })
 })

--- a/server/src/middleware/tests/AdminController.test.ts
+++ b/server/src/middleware/tests/AdminController.test.ts
@@ -809,7 +809,7 @@ describe("AdminController endpoint tests", () => {
     })
   })
 
-  describe("/admin/events/create", () => {
+  describe("/admin/events", () => {
     const event1: Event = {
       title: "UASC New event",
       physical_start_date: dateToFirestoreTimeStamp(new Date()),
@@ -820,7 +820,7 @@ describe("AdminController endpoint tests", () => {
 
     it("should let admins create an event", async () => {
       const res = await request
-        .post("/admin/events/create")
+        .post("/admin/events")
         .set("Authorization", `Bearer ${adminToken}`)
         .send({ data: event1 })
 

--- a/server/src/middleware/tests/AdminController.test.ts
+++ b/server/src/middleware/tests/AdminController.test.ts
@@ -826,7 +826,8 @@ describe("AdminController endpoint tests", () => {
 
       expect(res.status).toEqual(201)
 
-      expect(await new EventService().getAllEvents(1)).toHaveLength(1)
+      // There should not be more than 1, even if we request more
+      expect((await new EventService().getAllEvents(69)).events).toHaveLength(1)
     })
   })
 })

--- a/server/src/middleware/tests/EventController.test.ts
+++ b/server/src/middleware/tests/EventController.test.ts
@@ -12,7 +12,7 @@ const endDate = Timestamp.fromDate(new Date(2024, 1, 2))
 const event1: Event = {
   title: "UASC New event",
   location: "UASC",
-  physical_start_date: startDate,
+  physical_start_date: earlierStartDate,
   start_date: earlierStartDate,
   end_date: earlierStartDate
 }
@@ -44,9 +44,13 @@ describe("EventController endpoint tests", () => {
 
       let res = await request.get("/events").query({ limit: 1 }).send()
 
+      /**
+       * We should first fetch the events starting later...
+       */
       expect(res.body.data).toHaveLength(1)
       expect(res.body.data).not.toContainEqual({ ...event1, id: id1 })
       expect(res.body.data).toContainEqual({ ...event2, id: id2 })
+      expect(res.status).toEqual(200)
 
       res = await request
         .get("/events")
@@ -56,6 +60,7 @@ describe("EventController endpoint tests", () => {
       expect(res.body.data).toHaveLength(1)
       expect(res.body.data).toContainEqual({ ...event1, id: id1 })
       expect(res.body.data).not.toContainEqual({ ...event2, id: id2 })
+      expect(res.status).toEqual(200)
     })
   })
 

--- a/server/src/middleware/tests/EventController.test.ts
+++ b/server/src/middleware/tests/EventController.test.ts
@@ -1,13 +1,29 @@
 import EventService from "data-layer/services/EventService"
 import { request } from "../routes.setup"
 import { Event, EventReservation } from "../../data-layer/models/firebase"
-import { dateToFirestoreTimeStamp } from "data-layer/adapters/DateUtils"
+import { Timestamp } from "firebase-admin/firestore"
 
-const startDate = dateToFirestoreTimeStamp(new Date(2024, 1, 1))
-const endDate = dateToFirestoreTimeStamp(new Date(2024, 1, 2))
+const earlierStartDate = Timestamp.fromDate(new Date(2023, 1, 1))
+const startDate = Timestamp.fromDate(new Date(2024, 1, 1))
+const endDate = Timestamp.fromDate(new Date(2024, 1, 2))
+/**
+ * Event with the earlier start date
+ */
 const event1: Event = {
   title: "UASC New event",
   location: "UASC",
+  physical_start_date: startDate,
+  start_date: earlierStartDate,
+  end_date: earlierStartDate
+}
+
+/**
+ * Event witht the later start date
+ */
+const event2: Event = {
+  title: "Straight Zhao",
+  location: "UASC",
+  physical_start_date: startDate,
   start_date: startDate,
   end_date: endDate
 }
@@ -20,6 +36,29 @@ const reservation1: EventReservation = {
 
 describe("EventController endpoint tests", () => {
   const eventService = new EventService()
+
+  describe("GET /events", () => {
+    it("should fetch all events based on cursor", async () => {
+      const { id: id1 } = await eventService.createEvent(event1)
+      const { id: id2 } = await eventService.createEvent(event2)
+
+      let res = await request.get("/events").query({ limit: 1 }).send()
+
+      expect(res.body.data).toHaveLength(1)
+      expect(res.body.data).not.toContainEqual({ ...event1, id: id1 })
+      expect(res.body.data).toContainEqual({ ...event2, id: id2 })
+
+      res = await request
+        .get("/events")
+        .query({ cursor: res.body.nextCursor, limit: 1 })
+        .send()
+
+      expect(res.body.data).toHaveLength(1)
+      expect(res.body.data).toContainEqual({ ...event1, id: id1 })
+      expect(res.body.data).not.toContainEqual({ ...event2, id: id2 })
+    })
+  })
+
   describe("/events/signup", () => {
     it("should return 404 if the event does not exist", async () => {
       const res = await request.post("/events/signup").send({

--- a/server/src/service-layer/controllers/AdminController.ts
+++ b/server/src/service-layer/controllers/AdminController.ts
@@ -59,6 +59,8 @@ import BookingUtils, {
 } from "business-layer/utils/BookingUtils"
 import BookingHistoryService from "data-layer/services/BookingHistoryService"
 import { FetchLatestBookingHistoryEventResponse } from "service-layer/response-models/AdminResponse"
+import { CreateEventBody } from "service-layer/request-models/EventRequests"
+import EventService from "data-layer/services/EventService"
 
 @Route("admin")
 @Security("jwt", ["admin"])
@@ -690,6 +692,22 @@ export class AdminController extends Controller {
       return {
         error: "Unable to fetch the booking history"
       }
+    }
+  }
+
+  /**
+   * Endpoint for admin to create a new event
+   */
+  @SuccessResponse("201", "Created Event")
+  @Post("events/create")
+  public async createNewEvent(@Body() body: CreateEventBody) {
+    try {
+      const eventService = new EventService()
+      await eventService.createEvent(body.data)
+
+      this.setStatus(201)
+    } catch {
+      this.setStatus(500)
     }
   }
 }

--- a/server/src/service-layer/controllers/AdminController.ts
+++ b/server/src/service-layer/controllers/AdminController.ts
@@ -699,7 +699,7 @@ export class AdminController extends Controller {
    * Endpoint for admin to create a new event
    */
   @SuccessResponse("201", "Created Event")
-  @Post("events/create")
+  @Post("events")
   public async createNewEvent(@Body() body: CreateEventBody) {
     try {
       const eventService = new EventService()

--- a/server/src/service-layer/controllers/EventController.ts
+++ b/server/src/service-layer/controllers/EventController.ts
@@ -72,6 +72,10 @@ export class EventController extends Controller {
     }
   }
 
+  /**
+   * Fetches latest events starting from the event with the latest starting date
+   * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+   */
   @Get()
   @SuccessResponse("200", "Successfully fetched all events")
   public async getAllEvents(

--- a/server/src/service-layer/controllers/EventController.ts
+++ b/server/src/service-layer/controllers/EventController.ts
@@ -1,7 +1,18 @@
 import EventService from "data-layer/services/EventService"
 import { EventSignupBody } from "service-layer/request-models/EventRequests"
-import { EventSignupResponse } from "service-layer/response-models/EventResponse"
-import { Body, Controller, Post, Route, SuccessResponse } from "tsoa"
+import {
+  EventSignupResponse,
+  GetAllEventsResponse
+} from "service-layer/response-models/EventResponse"
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Route,
+  SuccessResponse
+} from "tsoa"
 
 @Route("events")
 export class EventController extends Controller {
@@ -56,6 +67,29 @@ export class EventController extends Controller {
     } catch (e) {
       this.setStatus(500)
       return { error: "Failed to sign up for event." }
+    }
+  }
+
+  @Get()
+  @SuccessResponse("200", "Successfully fetched all events")
+  public async getAllEvents(
+    @Query() limit: number = 20,
+    @Query() cursor?: string
+  ): Promise<GetAllEventsResponse> {
+    try {
+      const eventService = new EventService()
+
+      let snapshot
+      if (cursor) {
+        snapshot = await eventService.getEventSnapshot(cursor)
+      }
+
+      const res = await eventService.getAllEvents(limit, snapshot)
+      return { nextCursor: res.nextCursor, data: res.events }
+    } catch (e) {
+      return {
+        error: "Something went wrong when fetching all events, please try again"
+      }
     }
   }
 }

--- a/server/src/service-layer/request-models/EventRequests.ts
+++ b/server/src/service-layer/request-models/EventRequests.ts
@@ -1,6 +1,10 @@
-import { EventReservation } from "data-layer/models/firebase"
+import { EventReservation, Event } from "data-layer/models/firebase"
 
 export interface EventSignupBody {
   event_id: string
   reservation: EventReservation
+}
+
+export interface CreateEventBody {
+  data: Event
 }

--- a/server/src/service-layer/response-models/EventResponse.ts
+++ b/server/src/service-layer/response-models/EventResponse.ts
@@ -1,4 +1,5 @@
-import { CommonResponse } from "./CommonResponse"
+import { CommonResponse, CursorPaginatedResponse } from "./CommonResponse"
+import { Event } from "data-layer/models/firebase"
 
 export interface EventSignupResponse extends CommonResponse {
   data?: {
@@ -6,4 +7,10 @@ export interface EventSignupResponse extends CommonResponse {
     last_name: string
     email: string
   }
+}
+
+export interface GetAllEventsResponse
+  extends CommonResponse,
+    CursorPaginatedResponse {
+  data?: Event[]
 }


### PR DESCRIPTION
# Admin event creation and paginated fetching events

created two endpoints:

- `GET /events`
   - Allows users to do cursor based pagination on the latest events
- `POST /admin/events`
   - Simple **create** operation

Note the changes used for sorting timestamps in `server/src/data-layer/services/EventService.ts` need to be implemented in `BookingHistory` as the are currently not being sorted properly :skull:.


