### PR TITLE
Add google forms link as field to event and clarify fields

### DIFF
--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -362,21 +362,21 @@ export interface components {
        * Note that this date is in UTC time.
        * Use the same start and end date to indicate a 1 day signup period.
        */
-      start_date: components["schemas"]["FirebaseFirestore.Timestamp"];
+      sign_up_start_date: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
        * @description The signup period end date.
        * Note that this date is in UTC time.
        */
-      end_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
+      sign_up_end_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
        * @description Event start date for the event i.e the day members should meet at shads,
-       * **NOT** the signups, refer to {@link start_date} for signup start
+       * **NOT** the signups, refer to {@link sign_up_start_date} for signup start
        */
       physical_start_date: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
        * @description Event end time for the event i.e the last day members will be at the lodge,
        * is optionial in case of one day events. **NOT** the signups, refer to
-       * {@link end_date} for signup end date
+       * {@link sign_up_end_date} for signup end date
        */
       physical_end_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
@@ -748,21 +748,21 @@ export interface components {
        * Note that this date is in UTC time.
        * Use the same start and end date to indicate a 1 day signup period.
        */
-      start_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
+      sign_up_start_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
        * @description The signup period end date.
        * Note that this date is in UTC time.
        */
-      end_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
+      sign_up_end_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
        * @description Event start date for the event i.e the day members should meet at shads,
-       * **NOT** the signups, refer to {@link start_date} for signup start
+       * **NOT** the signups, refer to {@link sign_up_start_date} for signup start
        */
       physical_start_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
        * @description Event end time for the event i.e the last day members will be at the lodge,
        * is optionial in case of one day events. **NOT** the signups, refer to
-       * {@link end_date} for signup end date
+       * {@link sign_up_end_date} for signup end date
        */
       physical_end_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -351,7 +351,12 @@ export interface components {
       /** @description The link for the image to display on the event page (essentially a thumbnail) */
       image_url?: string;
       /** @description The location of this event */
-      location: string;
+      location?: string;
+      /**
+       * @description A URL to the google form for signing up to the event. This is not to be included
+       * in any response body unless we are _near_ the period for sign up
+       */
+      google_forms_link?: string;
       /**
        * @description The signup period start date.
        * Note that this date is in UTC time.
@@ -362,7 +367,7 @@ export interface components {
        * @description The signup period end date.
        * Note that this date is in UTC time.
        */
-      end_date: components["schemas"]["FirebaseFirestore.Timestamp"];
+      end_date?: components["schemas"]["FirebaseFirestore.Timestamp"];
       /**
        * @description Event start date for the event i.e the day members should meet at shads,
        * **NOT** the signups, refer to {@link start_date} for signup start
@@ -733,6 +738,11 @@ export interface components {
       image_url?: string;
       /** @description The location of this event */
       location?: string;
+      /**
+       * @description A URL to the google form for signing up to the event. This is not to be included
+       * in any response body unless we are _near_ the period for sign up
+       */
+      google_forms_link?: string;
       /**
        * @description The signup period start date.
        * Note that this date is in UTC time.

--- a/server/src/data-layer/models/firebase.ts
+++ b/server/src/data-layer/models/firebase.ts
@@ -173,7 +173,14 @@ export interface Event {
   /**
    * The location of this event
    */
-  location: string
+  location?: string
+
+  /**
+   * A URL to the google form for signing up to the event. This is not to be included
+   * in any response body unless we are _near_ the period for sign up
+   */
+  google_forms_link?: string
+
   /**
    * The signup period start date.
    * Note that this date is in UTC time.
@@ -185,7 +192,7 @@ export interface Event {
    * The signup period end date.
    * Note that this date is in UTC time.
    */
-  end_date: Timestamp
+  end_date?: Timestamp
 
   /**
    * Event start date for the event i.e the day members should meet at shads,

--- a/server/src/data-layer/models/firebase.ts
+++ b/server/src/data-layer/models/firebase.ts
@@ -186,24 +186,24 @@ export interface Event {
    * Note that this date is in UTC time.
    * Use the same start and end date to indicate a 1 day signup period.
    */
-  start_date: Timestamp
+  sign_up_start_date: Timestamp
 
   /**
    * The signup period end date.
    * Note that this date is in UTC time.
    */
-  end_date?: Timestamp
+  sign_up_end_date?: Timestamp
 
   /**
    * Event start date for the event i.e the day members should meet at shads,
-   * **NOT** the signups, refer to {@link start_date} for signup start
+   * **NOT** the signups, refer to {@link sign_up_start_date} for signup start
    */
   physical_start_date: Timestamp
 
   /**
    * Event end time for the event i.e the last day members will be at the lodge,
    * is optionial in case of one day events. **NOT** the signups, refer to
-   * {@link end_date} for signup end date
+   * {@link sign_up_end_date} for signup end date
    */
   physical_end_date?: Timestamp
 

--- a/server/src/data-layer/services/EventService.test.ts
+++ b/server/src/data-layer/services/EventService.test.ts
@@ -104,8 +104,10 @@ describe("EventService integration tests", () => {
 
     expect({
       ...data,
-      end_date: removeUnderscoresFromTimestamp(data.sign_up_end_date),
-      start_date: removeUnderscoresFromTimestamp(data.sign_up_start_date)
+      sign_up_end_date: removeUnderscoresFromTimestamp(data.sign_up_end_date),
+      sign_up_start_date: removeUnderscoresFromTimestamp(
+        data.sign_up_start_date
+      )
     }).toEqual(event1)
   })
 
@@ -116,8 +118,10 @@ describe("EventService integration tests", () => {
 
     expect({
       ...fetchedEvent,
-      end_date: removeUnderscoresFromTimestamp(fetchedEvent.sign_up_end_date),
-      start_date: removeUnderscoresFromTimestamp(
+      sign_up_end_date: removeUnderscoresFromTimestamp(
+        fetchedEvent.sign_up_end_date
+      ),
+      sign_up_start_date: removeUnderscoresFromTimestamp(
         fetchedEvent.sign_up_start_date
       )
     }).toEqual(event1)

--- a/server/src/data-layer/services/EventService.test.ts
+++ b/server/src/data-layer/services/EventService.test.ts
@@ -22,16 +22,16 @@ const event1: Event = {
   description: "Grand opening of the website.",
   location: "Virtual pizza event",
   physical_start_date: startTimestamp,
-  start_date: startTimestamp,
-  end_date: endTimestamp
+  sign_up_start_date: startTimestamp,
+  sign_up_end_date: endTimestamp
 }
 const event2: Event = {
   title: "Snowboard racing",
   description: "Race and see who's the fastest!",
   location: "Snowsport club",
   physical_start_date: startTimestamp,
-  start_date: startTimestamp,
-  end_date: endTimestamp
+  sign_up_start_date: startTimestamp,
+  sign_up_end_date: endTimestamp
 }
 const now = new Date(Date.now())
 const futureEvent: Event = {
@@ -40,8 +40,10 @@ const futureEvent: Event = {
   physical_start_date: Timestamp.fromDate(
     new Date(now.getUTCFullYear() + 1, 1, 1)
   ),
-  start_date: Timestamp.fromDate(new Date(now.getUTCFullYear() + 1, 1, 1)),
-  end_date: Timestamp.fromDate(new Date(now.getUTCFullYear() + 1, 1, 1))
+  sign_up_start_date: Timestamp.fromDate(
+    new Date(now.getUTCFullYear() + 1, 1, 1)
+  ),
+  sign_up_end_date: Timestamp.fromDate(new Date(now.getUTCFullYear() + 1, 1, 1))
 }
 
 const reservation1: EventReservation = {
@@ -102,8 +104,8 @@ describe("EventService integration tests", () => {
 
     expect({
       ...data,
-      end_date: removeUnderscoresFromTimestamp(data.end_date),
-      start_date: removeUnderscoresFromTimestamp(data.start_date)
+      end_date: removeUnderscoresFromTimestamp(data.sign_up_end_date),
+      start_date: removeUnderscoresFromTimestamp(data.sign_up_start_date)
     }).toEqual(event1)
   })
 
@@ -114,8 +116,10 @@ describe("EventService integration tests", () => {
 
     expect({
       ...fetchedEvent,
-      end_date: removeUnderscoresFromTimestamp(fetchedEvent.end_date),
-      start_date: removeUnderscoresFromTimestamp(fetchedEvent.start_date)
+      end_date: removeUnderscoresFromTimestamp(fetchedEvent.sign_up_end_date),
+      start_date: removeUnderscoresFromTimestamp(
+        fetchedEvent.sign_up_start_date
+      )
     }).toEqual(event1)
   })
 

--- a/server/src/data-layer/services/EventService.ts
+++ b/server/src/data-layer/services/EventService.ts
@@ -36,7 +36,7 @@ class EventService {
     const now = new Date(Date.now())
 
     const result = await FirestoreCollections.events
-      .where("end_date", ">", now) // Only get events that have not ended
+      .where("sign_up_end_date", ">", now) // Only get events that have not ended
       .get()
 
     return result.docs.map((doc) => {

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -215,9 +215,10 @@ const models: TsoaRoute.Models = {
             "title": {"dataType":"string","required":true},
             "description": {"dataType":"string"},
             "image_url": {"dataType":"string"},
-            "location": {"dataType":"string","required":true},
+            "location": {"dataType":"string"},
+            "google_forms_link": {"dataType":"string"},
             "start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
-            "end_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
+            "end_date": {"ref":"FirebaseFirestore.Timestamp"},
             "physical_start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
             "physical_end_date": {"ref":"FirebaseFirestore.Timestamp"},
             "max_occupancy": {"dataType":"double"},
@@ -568,7 +569,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_Event_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"description":{"dataType":"string"},"image_url":{"dataType":"string"},"location":{"dataType":"string"},"start_date":{"ref":"FirebaseFirestore.Timestamp"},"end_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_start_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_end_date":{"ref":"FirebaseFirestore.Timestamp"},"max_occupancy":{"dataType":"double"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"description":{"dataType":"string"},"image_url":{"dataType":"string"},"location":{"dataType":"string"},"google_forms_link":{"dataType":"string"},"start_date":{"ref":"FirebaseFirestore.Timestamp"},"end_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_start_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_end_date":{"ref":"FirebaseFirestore.Timestamp"},"max_occupancy":{"dataType":"double"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -217,8 +217,8 @@ const models: TsoaRoute.Models = {
             "image_url": {"dataType":"string"},
             "location": {"dataType":"string"},
             "google_forms_link": {"dataType":"string"},
-            "start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
-            "end_date": {"ref":"FirebaseFirestore.Timestamp"},
+            "sign_up_start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
+            "sign_up_end_date": {"ref":"FirebaseFirestore.Timestamp"},
             "physical_start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
             "physical_end_date": {"ref":"FirebaseFirestore.Timestamp"},
             "max_occupancy": {"dataType":"double"},
@@ -569,7 +569,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_Event_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"description":{"dataType":"string"},"image_url":{"dataType":"string"},"location":{"dataType":"string"},"google_forms_link":{"dataType":"string"},"start_date":{"ref":"FirebaseFirestore.Timestamp"},"end_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_start_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_end_date":{"ref":"FirebaseFirestore.Timestamp"},"max_occupancy":{"dataType":"double"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"description":{"dataType":"string"},"image_url":{"dataType":"string"},"location":{"dataType":"string"},"google_forms_link":{"dataType":"string"},"sign_up_start_date":{"ref":"FirebaseFirestore.Timestamp"},"sign_up_end_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_start_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_end_date":{"ref":"FirebaseFirestore.Timestamp"},"max_occupancy":{"dataType":"double"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -497,21 +497,21 @@
 						"type": "string",
 						"description": "A URL to the google form for signing up to the event. This is not to be included\nin any response body unless we are _near_ the period for sign up"
 					},
-					"start_date": {
+					"sign_up_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
 						"description": "The signup period start date.\nNote that this date is in UTC time.\nUse the same start and end date to indicate a 1 day signup period."
 					},
-					"end_date": {
+					"sign_up_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
 						"description": "The signup period end date.\nNote that this date is in UTC time."
 					},
 					"physical_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event start date for the event i.e the day members should meet at shads,\n**NOT** the signups, refer to {@link start_date} for signup start"
+						"description": "Event start date for the event i.e the day members should meet at shads,\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
 					},
 					"physical_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event end time for the event i.e the last day members will be at the lodge,\nis optionial in case of one day events. **NOT** the signups, refer to\n{@link end_date} for signup end date"
+						"description": "Event end time for the event i.e the last day members will be at the lodge,\nis optionial in case of one day events. **NOT** the signups, refer to\n{@link sign_up_end_date} for signup end date"
 					},
 					"max_occupancy": {
 						"type": "number",
@@ -522,7 +522,7 @@
 				},
 				"required": [
 					"title",
-					"start_date",
+					"sign_up_start_date",
 					"physical_start_date"
 				],
 				"type": "object",
@@ -1442,21 +1442,21 @@
 						"type": "string",
 						"description": "A URL to the google form for signing up to the event. This is not to be included\nin any response body unless we are _near_ the period for sign up"
 					},
-					"start_date": {
+					"sign_up_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
 						"description": "The signup period start date.\nNote that this date is in UTC time.\nUse the same start and end date to indicate a 1 day signup period."
 					},
-					"end_date": {
+					"sign_up_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
 						"description": "The signup period end date.\nNote that this date is in UTC time."
 					},
 					"physical_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event start date for the event i.e the day members should meet at shads,\n**NOT** the signups, refer to {@link start_date} for signup start"
+						"description": "Event start date for the event i.e the day members should meet at shads,\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
 					},
 					"physical_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event end time for the event i.e the last day members will be at the lodge,\nis optionial in case of one day events. **NOT** the signups, refer to\n{@link end_date} for signup end date"
+						"description": "Event end time for the event i.e the last day members will be at the lodge,\nis optionial in case of one day events. **NOT** the signups, refer to\n{@link sign_up_end_date} for signup end date"
 					},
 					"max_occupancy": {
 						"type": "number",

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -493,6 +493,10 @@
 						"type": "string",
 						"description": "The location of this event"
 					},
+					"google_forms_link": {
+						"type": "string",
+						"description": "A URL to the google form for signing up to the event. This is not to be included\nin any response body unless we are _near_ the period for sign up"
+					},
 					"start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
 						"description": "The signup period start date.\nNote that this date is in UTC time.\nUse the same start and end date to indicate a 1 day signup period."
@@ -518,9 +522,7 @@
 				},
 				"required": [
 					"title",
-					"location",
 					"start_date",
-					"end_date",
 					"physical_start_date"
 				],
 				"type": "object",
@@ -1435,6 +1437,10 @@
 					"location": {
 						"type": "string",
 						"description": "The location of this event"
+					},
+					"google_forms_link": {
+						"type": "string",
+						"description": "A URL to the google form for signing up to the event. This is not to be included\nin any response body unless we are _near_ the period for sign up"
 					},
 					"start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",

--- a/server/src/middleware/tests/AdminController.test.ts
+++ b/server/src/middleware/tests/AdminController.test.ts
@@ -814,8 +814,8 @@ describe("AdminController endpoint tests", () => {
       title: "UASC New event",
       physical_start_date: dateToFirestoreTimeStamp(new Date()),
       location: "UASC",
-      start_date: dateToFirestoreTimeStamp(new Date()),
-      end_date: dateToFirestoreTimeStamp(new Date())
+      sign_up_start_date: dateToFirestoreTimeStamp(new Date()),
+      sign_up_end_date: dateToFirestoreTimeStamp(new Date())
     }
     const eventService = new EventService()
 

--- a/server/src/middleware/tests/EventController.test.ts
+++ b/server/src/middleware/tests/EventController.test.ts
@@ -13,8 +13,8 @@ const event1: Event = {
   title: "UASC New event",
   location: "UASC",
   physical_start_date: earlierStartDate,
-  start_date: earlierStartDate,
-  end_date: earlierStartDate
+  sign_up_start_date: earlierStartDate,
+  sign_up_end_date: earlierStartDate
 }
 
 /**
@@ -24,8 +24,8 @@ const event2: Event = {
   title: "Straight Zhao",
   location: "UASC",
   physical_start_date: startDate,
-  start_date: startDate,
-  end_date: endDate
+  sign_up_start_date: startDate,
+  sign_up_end_date: endDate
 }
 const reservation1: Omit<EventReservation, "timestamp"> = {
   first_name: "John",

--- a/server/src/service-layer/controllers/AdminController.ts
+++ b/server/src/service-layer/controllers/AdminController.ts
@@ -705,13 +705,13 @@ export class AdminController extends Controller {
       const eventService = new EventService()
       await eventService.createEvent({
         ...body.data,
-        start_date: new Timestamp(
-          body.data.start_date.seconds,
-          body.data.start_date.nanoseconds
+        sign_up_start_date: new Timestamp(
+          body.data.sign_up_start_date.seconds,
+          body.data.sign_up_start_date.nanoseconds
         ),
-        end_date: new Timestamp(
-          body.data.end_date.seconds,
-          body.data.end_date.nanoseconds
+        sign_up_end_date: new Timestamp(
+          body.data.sign_up_end_date.seconds,
+          body.data.sign_up_end_date.nanoseconds
         ),
         physical_start_date: new Timestamp(
           body.data.physical_start_date.seconds,


### PR DESCRIPTION
This is because we are removing the firestore signups for events in #797. This field is also optional so the event can be created pretty far out from the sign up date.

Renamed the `start_date` and `end_date` to `sign_up_start_date` and `sign_up_end_date` to fix the bad naming