### PR TITLE
fix double initialistation of firebase when creating storage service

### DIFF
--- a/client/src/firebase.ts
+++ b/client/src/firebase.ts
@@ -17,6 +17,7 @@ import { MembershipPaymentStore } from "@/store/MembershipPayment"
 import queryClient from "@/services/QueryClient"
 import { BOOKING_AVAILABLITY_KEY } from "@/services/Booking/BookingQueries"
 import { MEMBERSHIP_CLIENT_SECRET_KEY } from "@/services/Payment/PaymentQueries"
+import { getStorage } from "firebase/storage"
 
 const firebaseConfig: FirebaseOptions = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -31,6 +32,7 @@ const firebaseConfig: FirebaseOptions = {
 const app = initializeApp(firebaseConfig)
 const auth = getAuth(app)
 const db = getFirestore(app)
+const storage = getStorage(app)
 let analytics: Analytics | null = null
 
 isSupported().then((yes) => {
@@ -80,4 +82,4 @@ export const fireAnalytics = (
   }
 }
 
-export { auth, db, analytics }
+export { auth, db, analytics, storage }

--- a/client/src/services/Storage/StorageService.ts
+++ b/client/src/services/Storage/StorageService.ts
@@ -1,11 +1,9 @@
+import { storage } from "@/firebase"
 import {
   getDownloadURL,
   ref as storageRef,
-  uploadBytes,
-  getStorage
+  uploadBytes
 } from "firebase/storage"
-
-const storage = getStorage()
 
 // https://stackoverflow.com/a/19842865
 const uid = () => {


### PR DESCRIPTION
same issue as https://github.com/vercel/next.js/discussions/11351https://github.com/vercel/next.js/discussions/11351, however we just need to not call `getStorage` raw without passing in the firebase app

This was causing the `admin/events` build to sometimes fail