### PR TITLE
allow form to be used for both editing and creating

### DIFF
--- a/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.story.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import AdminEventForm from "./AdminEventForm"
+import { Timestamp } from "firebase/firestore"
 
 const meta: Meta<typeof AdminEventForm> = {
   component: AdminEventForm
@@ -9,3 +10,21 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const DefaultAdminEventForm: Story = {}
+
+export const DefaultAdminEventFormEditView: Story = {
+  args: {
+    isEditMode: true,
+    defaultData: {
+      title: "Goon Cave",
+      description:
+        "Lorem, ipsum dolor sit amet consectetur adipisicing elit. Eaque officiis similique repellat accusantium eos dignissimos suscipit voluptatibus? Quia nobis repellendus quam, aliquid, veritatis eos fuga eligendi harum dolorum vero facere!",
+      location: "straight zhao's basement",
+      sign_up_start_date: Timestamp.fromDate(new Date(2024, 10, 4)),
+      sign_up_end_date: Timestamp.fromDate(new Date(2024, 11, 5)),
+      physical_start_date: Timestamp.fromDate(new Date(2024, 10, 3)),
+      physical_end_date: Timestamp.fromDate(new Date(2024, 11, 3)),
+      google_forms_link:
+        "https://www.reddit.com/r/VrGoonCave/comments/18gnrk8/welcome_to_vrgooncave/"
+    }
+  }
+}

--- a/client/src/components/generic/Event/EventPreview/EventPreview.tsx
+++ b/client/src/components/generic/Event/EventPreview/EventPreview.tsx
@@ -84,7 +84,7 @@ const EventsCardPreview = ({
     <div
       className={`border-gray-3 navbar-shadow flex w-full flex-col items-center
           	    justify-center gap-2 rounded-md border bg-white p-4 sm:flex-row
-                sm:px-10 sm:py-${variant === "admin" ? 10 : 12} ${isPastEvent && "brightness-50"}`}
+                sm:px-10 ${variant === "admin" ? "sm:py-10" : "sm:py-12"} ${isPastEvent && "brightness-50"}`}
     >
       <div className="border-gray-3 h-fit max-h-[150px] w-[200px] overflow-hidden border">
         <Image

--- a/client/src/components/generic/Event/EventUtils.test.ts
+++ b/client/src/components/generic/Event/EventUtils.test.ts
@@ -1,0 +1,33 @@
+import { EventRenderingUtils } from "./EventUtils"
+
+describe("dateTimeLocalPlaceHolder", () => {
+  it("should return a formatted string in ISO 8601 format without milliseconds", () => {
+    const date = new Date("2024-11-01T23:34:15.123Z")
+    const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
+    expect(result).toBe("2024-11-01T23:34:15")
+  })
+
+  it("should handle dates without milliseconds correctly", () => {
+    const date = new Date("2024-11-01T23:34:15Z")
+    const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
+    expect(result).toBe("2024-11-01T23:34:15")
+  })
+
+  it("should handle different time zones correctly", () => {
+    const date = new Date("2024-11-01T23:34:15.123+09:00")
+    const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
+    expect(result).toBe("2024-11-01T14:34:15")
+  })
+
+  it("should handle leap years correctly", () => {
+    const date = new Date("2024-02-29T23:34:15.123Z")
+    const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
+    expect(result).toBe("2024-02-29T23:34:15")
+  })
+
+  it("should handle dates before 1970 correctly", () => {
+    const date = new Date("1969-12-31T23:34:15.123Z")
+    const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
+    expect(result).toBe("1969-12-31T23:34:15")
+  })
+})

--- a/client/src/components/generic/Event/EventUtils.ts
+++ b/client/src/components/generic/Event/EventUtils.ts
@@ -11,6 +11,20 @@ export const IMAGE_PLACEHOLDER_SRC =
  */
 export const EventMessages = {
   /**
+   * Message to be displayed for confirming event creation or editing
+   *
+   * @param isEditing boolean indicating if the event is being edited
+   * @param title the title of the event
+   * @returns a formatted, user-readable string asking for confirmation
+   */
+  adminEventPostConfirmation: (isEditing: boolean, title: string) => {
+    if (isEditing) {
+      return `Are you sure you want to edit the event ${title}?`
+    } else {
+      return `Are you sure you want to create the new event with title ${title}?`
+    }
+  },
+  /**
    * Message to be displayed if sign ups have opened in relation to the sign up date
    *
    * @param signUpOpenDate the date object corresponding to the timestamp when the sign ups open
@@ -69,6 +83,17 @@ export const EventDateComparisons = {
 } as const
 
 export const EventRenderingUtils = {
+  /**
+   * Generates a placeholder string for a local date and time input field
+   *
+   * @param date the date object to be formatted
+   * @returns a formatted string in ISO 8601 format without milliseconds
+   */
+  dateTimeLocalPlaceHolder: (date: Date) => {
+    const isoString = date.toISOString()
+    const placeholderString = isoString.substring(0, isoString.lastIndexOf("."))
+    return placeholderString
+  },
   /**
    * Utility function to convert a raw {@link Event} into {@link IEventsCardPreview}
    *


### PR DESCRIPTION
Added two props to the `AdminEventForm`:

- `isEditingMode`
- `defaultData`

Which allow the form to be used to send edit requests with the `PATCH` endpoint for events

>[!NOTE]
>Also fixed the padding in the Event Preview, because the use of numbers conditionally stopped tailwind from being compiled properly

## Normal Create View

![image](https://github.com/user-attachments/assets/c4374751-4c47-4d36-877d-1b3df0b6f60b)


## Editing View

![image](https://github.com/user-attachments/assets/4e155a00-cfa2-4a99-802e-bc84883f3d40)


