### PR TITLE
816 frontend implement editing functionality for events

### DIFF
--- a/client/src/components/composite/Admin/AdminEventView/AdminAllEvents/AdminAllEvents.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminAllEvents/AdminAllEvents.tsx
@@ -1,6 +1,4 @@
-import EventsCardPreview, {
-  IEventsCardPreview
-} from "@/components/generic/Event/EventPreview/EventPreview"
+import EventsCardPreview from "@/components/generic/Event/EventPreview/EventPreview"
 import { DateUtils } from "@/components/utils/DateUtils"
 import { Event } from "@/models/Events"
 import { useCallback, useMemo, useState } from "react"
@@ -127,7 +125,7 @@ const AdminAllEvents = ({
   /**
    * Detailed view of the event
    */
-  const previewCurrentEvents: IEventsCardPreview[] =
+  const previewCurrentEvents =
     eventList.upcomingAndCurrentEvents?.map((event) => {
       return EventRenderingUtils.previewTransformer(
         event,
@@ -137,7 +135,7 @@ const AdminAllEvents = ({
       )
     }) || []
 
-  const previewPastEvents: IEventsCardPreview[] =
+  const previewPastEvents =
     eventList.pastEvents?.map((event) => {
       return EventRenderingUtils.previewTransformer(
         event,
@@ -164,11 +162,11 @@ const AdminAllEvents = ({
               </h5>
             )}
             {previewCurrentEvents.map((event) => (
-              <EventsCardPreview key={event.title} {...event} />
+              <EventsCardPreview {...event} key={event.key} />
             ))}
 
             {previewPastEvents.map((event) => (
-              <EventsCardPreview key={event.title} {...event} />
+              <EventsCardPreview {...event} key={event.key} />
             ))}
           </>
         )}

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.tsx
@@ -42,6 +42,18 @@ interface IAdminEventForm {
   defaultData?: CreateEventBody["data"]
 }
 
+const USER_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+const TimezoneIndicator = () => (
+  <>
+    {USER_TIMEZONE && (
+      <h5 className="text-center font-bold uppercase">
+        The timezone is: {USER_TIMEZONE}
+      </h5>
+    )}
+  </>
+)
+
 export const AdminEventFormKeys = {
   TITLE: "title",
   DESCRIPTION: "description",
@@ -102,7 +114,11 @@ const AdminEventForm = ({
         Number.parseInt(data.get(AdminEventFormKeys.MAX_OCCUPANCY) as string) ||
         undefined,
       physical_end_date: physical_end_date
-        ? Timestamp.fromDate(new Date(physical_end_date as string))
+        ? Timestamp.fromDate(
+            new Date(
+              (physical_end_date as string).replace(/-/g, "/").replace("T", " ")
+            )
+          )
         : undefined
     }
 
@@ -184,7 +200,7 @@ const AdminEventForm = ({
             name={AdminEventFormKeys.SIGN_UP_START_DATE}
             data-testid={AdminEventFormKeys.SIGN_UP_START_DATE}
             type="datetime-local"
-            value={
+            defaultValue={
               defaultData &&
               EventRenderingUtils.dateTimeLocalPlaceHolder(
                 new Date(
@@ -200,7 +216,7 @@ const AdminEventForm = ({
           <TextInput
             name={AdminEventFormKeys.SIGN_UP_END_DATE}
             data-testid={AdminEventFormKeys.SIGN_UP_END_DATE}
-            value={
+            defaultValue={
               defaultData?.sign_up_end_date &&
               EventRenderingUtils.dateTimeLocalPlaceHolder(
                 new Date(
@@ -212,14 +228,14 @@ const AdminEventForm = ({
             label="Sign Up End Date (If exists)"
           />
         </span>
-
+        <TimezoneIndicator />
         <Divider />
         <h3 className="text-dark-blue-100 mt-2 text-center">Event Dates</h3>
         <span className="flex w-full flex-col gap-2 sm:flex-row">
           <TextInput
             name={AdminEventFormKeys.PHYSICAL_START_DATE}
             data-testid={AdminEventFormKeys.PHYSICAL_START_DATE}
-            value={
+            defaultValue={
               defaultData?.physical_start_date &&
               EventRenderingUtils.dateTimeLocalPlaceHolder(
                 new Date(
@@ -236,7 +252,7 @@ const AdminEventForm = ({
           <TextInput
             name={AdminEventFormKeys.PHYSICAL_END_DATE}
             data-testid={AdminEventFormKeys.PHYSICAL_END_DATE}
-            value={
+            defaultValue={
               defaultData?.physical_end_date &&
               EventRenderingUtils.dateTimeLocalPlaceHolder(
                 new Date(
@@ -250,6 +266,7 @@ const AdminEventForm = ({
             label="End Date of Event"
           />
         </span>
+        <TimezoneIndicator />
         <Divider />
         <TextInput
           name={AdminEventFormKeys.GOOGLE_FORMS_LINK}

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.tsx
@@ -26,8 +26,18 @@ interface IAdminEventForm {
 
   /**
    * To be called after user submits the new data for the event
+   *
+   * (the big call to action button)
    */
   handlePostEvent: (data: CreateEventBody) => void
+
+  /**
+   * Handler which is passed in if {@link isEditMode} is `true`,
+   *
+   * if the user confirms they want the event deleted this handler will be called
+   */
+  handleDeleteEvent?: () => void
+
   /**
    * If the panel should suggest that the event is being edited, instead of created
    *
@@ -73,7 +83,8 @@ const AdminEventForm = ({
   handlePostEvent,
   generateImageLink,
   isEditMode = false,
-  defaultData
+  defaultData,
+  handleDeleteEvent
 }: IAdminEventForm) => {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
@@ -144,6 +155,20 @@ const AdminEventForm = ({
   return (
     <div className="relative my-4 flex w-full flex-col items-center rounded-md bg-white p-2">
       <h2 className="text-dark-blue-100">{formTitle}</h2>
+      {isEditMode && (
+        <button
+          className="mt-2"
+          onClick={() => {
+            confirm(
+              EventMessages.adminDeleteEventConfirmation(
+                defaultData?.title || ""
+              )
+            ) && handleDeleteEvent?.()
+          }}
+        >
+          <h5 className="text-red font-bold uppercase">Delete Event</h5>
+        </button>
+      )}
       <form
         onSubmit={handleSubmit}
         className="flex w-full max-w-[800px] flex-col gap-2"

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventView.story.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventView.story.tsx
@@ -29,6 +29,17 @@ export const AdminEventViewWithEvents: Story = {
     generateImageLink: async () => {
       return undefined
     },
+    eventPreviousData: {
+      id: "1",
+      title: "CACK",
+      location: "STRAIGHT ZHAO",
+      physical_start_date: earlierStartDate,
+      physical_end_date: earlierStartDate,
+      sign_up_start_date: earlierStartDate,
+      sign_up_end_date: earlierStartDate,
+      google_forms_link: "https://google.com",
+      description: "default data"
+    },
     rawEvents: [
       {
         id: "1",

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
@@ -74,22 +74,24 @@ const AdminEventViewContent = ({
   fetchMoreEvents,
   handleEditEvent,
   selectedEventId,
-  setEventId,
   eventPreviousData,
   fetchEventToEdit
 }: {
   mode: EventViewModes
+
+  /**
+   * Used to make the `PATCH` request for the event (need to specify path with `id`)
+   */
+  selectedEventId?: string
   setEventId: (id?: string) => void
   setMode: (mode: EventViewModes) => void
-  selectedEventId?: string
 } & IAdminEventView) => {
   switch (mode) {
     case "view-all-events":
       return (
         <AdminAllEvents
           onSelectedEventIdChange={async (id) => {
-            await fetchEventToEdit?.(id)
-            setEventId(id)
+            fetchEventToEdit?.(id)
             setMode("editing-event")
           }}
           rawEvents={rawEvents}
@@ -115,6 +117,11 @@ const AdminEventViewContent = ({
         setMode("view-all-events")
         return <Loader />
       }
+
+      if (!eventPreviousData) {
+        return <Loader />
+      }
+
       return (
         <AdminEventForm
           generateImageLink={async (image) => {
@@ -180,7 +187,7 @@ const AdminEventView = ({
                   setMode("view-all-events")
                   break
                 case "editing-event":
-                  fetchEventToEdit?.(undefined)
+                  fetchEventToEdit?.()
                   setMode("view-all-events")
               }
             }}

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
@@ -73,24 +73,23 @@ const AdminEventViewContent = ({
   isLoading,
   fetchMoreEvents,
   handleEditEvent,
-  selectedEventId,
   eventPreviousData,
   fetchEventToEdit
 }: {
   mode: EventViewModes
-
+  setMode: (mode: EventViewModes) => void
+} & IAdminEventView) => {
   /**
    * Used to make the `PATCH` request for the event (need to specify path with `id`)
    */
-  selectedEventId?: string
-  setEventId: (id?: string) => void
-  setMode: (mode: EventViewModes) => void
-} & IAdminEventView) => {
+  const [editedEventId, setEditedEventId] = useState<string | undefined>()
+
   switch (mode) {
     case "view-all-events":
       return (
         <AdminAllEvents
-          onSelectedEventIdChange={async (id) => {
+          onSelectedEventIdChange={(id) => {
+            setEditedEventId(id)
             fetchEventToEdit?.(id)
             setMode("editing-event")
           }}
@@ -113,7 +112,7 @@ const AdminEventViewContent = ({
         />
       )
     case "editing-event":
-      if (!selectedEventId) {
+      if (!editedEventId) {
         setMode("view-all-events")
         return <Loader />
       }
@@ -129,7 +128,7 @@ const AdminEventViewContent = ({
           }}
           defaultData={eventPreviousData}
           handlePostEvent={async (data) => {
-            await handleEditEvent?.(selectedEventId, data.data)
+            await handleEditEvent?.(editedEventId, data.data)
             setMode("view-all-events")
           }}
           isEditMode
@@ -169,8 +168,6 @@ const AdminEventView = ({
 }: IAdminEventView) => {
   const [mode, setMode] = useState<EventViewModes>("view-all-events")
 
-  const [editedEventId, setEditedEventId] = useState<string | undefined>()
-
   return (
     <div className="flex w-full flex-col items-center">
       <span className="flex w-full flex-col items-center sm:flex-row">
@@ -201,8 +198,6 @@ const AdminEventView = ({
         mode={mode}
         fetchEventToEdit={fetchEventToEdit}
         handleEditEvent={handleEditEvent}
-        setEventId={setEditedEventId}
-        selectedEventId={editedEventId}
         handlePostEvent={handlePostEvent}
         generateImageLink={generateImageLink}
         rawEvents={rawEvents}

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
@@ -75,7 +75,8 @@ const AdminEventViewContent = ({
   handleEditEvent,
   selectedEventId,
   setEventId,
-  eventPreviousData
+  eventPreviousData,
+  fetchEventToEdit
 }: {
   mode: EventViewModes
   setEventId: (id?: string) => void
@@ -86,7 +87,8 @@ const AdminEventViewContent = ({
     case "view-all-events":
       return (
         <AdminAllEvents
-          onSelectedEventIdChange={(id) => {
+          onSelectedEventIdChange={async (id) => {
+            await fetchEventToEdit?.(id)
             setEventId(id)
             setMode("editing-event")
           }}
@@ -154,7 +156,9 @@ const AdminEventView = ({
   hasMoreEvents,
   isLoading,
   fetchMoreEvents,
-  eventPreviousData
+  eventPreviousData,
+  handleEditEvent,
+  fetchEventToEdit
 }: IAdminEventView) => {
   const [mode, setMode] = useState<EventViewModes>("view-all-events")
 
@@ -176,6 +180,7 @@ const AdminEventView = ({
                   setMode("view-all-events")
                   break
                 case "editing-event":
+                  fetchEventToEdit?.(undefined)
                   setMode("view-all-events")
               }
             }}
@@ -187,6 +192,8 @@ const AdminEventView = ({
       <AdminEventViewContent
         setMode={setMode}
         mode={mode}
+        fetchEventToEdit={fetchEventToEdit}
+        handleEditEvent={handleEditEvent}
         setEventId={setEditedEventId}
         selectedEventId={editedEventId}
         handlePostEvent={handlePostEvent}

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
@@ -193,6 +193,7 @@ const AdminEventView = ({
           </Button>
         </div>
       </span>
+      {/** TODO: pass in delete handler */}
       <AdminEventViewContent
         setMode={setMode}
         mode={mode}

--- a/client/src/components/composite/Admin/AdminEventView/WrappedAdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/WrappedAdminEventView.tsx
@@ -52,6 +52,13 @@ const WrappedAdminEventView = () => {
         fetchEventToEdit={async (id) => {
           if (id) {
             setEventPreviousData(await fetchEventToBeEdited(id))
+          } else {
+            /**
+             * If we go back to the main screen we
+             * don't have an event id thats being edited,
+             * so we have to consider the data stale
+             */
+            setEventPreviousData(undefined)
           }
         }}
         handleEditEvent={async (eventId, newData) => {

--- a/client/src/components/composite/Admin/AdminEventView/WrappedAdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/WrappedAdminEventView.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { useCreateEventMutation } from "@/services/Admin/AdminMutations"
+import {
+  useCreateEventMutation,
+  useEditEventMutation
+} from "@/services/Admin/AdminMutations"
 import AdminEventView from "./AdminEventView"
 import StorageService from "@/services/Storage/StorageService"
 import { useLatestEventsQuery } from "@/services/Event/EventQueries"
@@ -16,6 +19,9 @@ const WrappedAdminEventView = () => {
     fetchNextPage,
     isFetchingNextPage
   } = useLatestEventsQuery()
+
+  const { mutateAsync: editEvent } = useEditEventMutation()
+
   const rawEvents = useMemo(() => {
     const flattenedEvents = data?.pages.flatMap((page) => {
       return page.data || []
@@ -30,6 +36,9 @@ const WrappedAdminEventView = () => {
         generateImageLink={async (image) =>
           await StorageService.uploadEventImage(image)
         }
+        handleEditEvent={async (eventId, newData) => {
+          await editEvent({ eventId, newData })
+        }}
         rawEvents={rawEvents || []}
         hasMoreEvents={hasNextPage}
         isLoading={isPending}

--- a/client/src/components/composite/EventsView/EventsView.tsx
+++ b/client/src/components/composite/EventsView/EventsView.tsx
@@ -1,6 +1,4 @@
-import EventsCardPreview, {
-  IEventsCardPreview
-} from "@/components/generic/Event/EventPreview/EventPreview"
+import EventsCardPreview from "@/components/generic/Event/EventPreview/EventPreview"
 import EventDetailed from "@/components/generic/Event/EventDetailed/EventDetailed"
 import { DateUtils } from "@/components/utils/DateUtils"
 import { Event } from "@/models/Events"
@@ -195,7 +193,7 @@ const EventsPage = ({
     )
   }, [selectedEventObject, eventSelectionHandler])
 
-  const previewCurrentEvents: IEventsCardPreview[] =
+  const previewCurrentEvents =
     eventList.upcomingAndCurrentEvents?.map((event) => {
       return EventRenderingUtils.previewTransformer(
         event,
@@ -204,7 +202,7 @@ const EventsPage = ({
       )
     }) || []
 
-  const previewPastEvents: IEventsCardPreview[] =
+  const previewPastEvents =
     eventList.pastEvents?.map((event) => {
       return EventRenderingUtils.previewTransformer(
         event,
@@ -235,11 +233,11 @@ const EventsPage = ({
               </h5>
             )}
             {previewCurrentEvents.map((event) => (
-              <EventsCardPreview key={event.title} {...event} />
+              <EventsCardPreview {...event} key={event.key} />
             ))}
 
             {previewPastEvents.map((event) => (
-              <EventsCardPreview key={event.title} {...event} />
+              <EventsCardPreview {...event} key={event.key} />
             ))}
           </>
         )}

--- a/client/src/components/generic/Event/EventUtils.test.ts
+++ b/client/src/components/generic/Event/EventUtils.test.ts
@@ -1,33 +1,27 @@
 import { EventRenderingUtils } from "./EventUtils"
 
 describe("dateTimeLocalPlaceHolder", () => {
-  it("should return a formatted string in ISO 8601 format without milliseconds", () => {
-    const date = new Date("2024-11-01T23:34:15.123Z")
+  it("should format the date correctly in ISO 8601 format without milliseconds", () => {
+    const date = new Date("2024-11-03T01:14:00Z")
     const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("2024-11-01T23:34:15")
+    expect(result).toBe("2024-11-03T01:14")
   })
 
-  it("should handle dates without milliseconds correctly", () => {
-    const date = new Date("2024-11-01T23:34:15Z")
+  it("should pad single digit months, days, hours, and minutes with leading zeros", () => {
+    const date = new Date("2024-01-05T03:09:00Z")
     const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("2024-11-01T23:34:15")
+    expect(result).toBe("2024-01-05T03:09")
   })
 
-  it("should handle different time zones correctly", () => {
-    const date = new Date("2024-11-01T23:34:15.123+09:00")
+  it("should handle dates with double digit months, days, hours, and minutes correctly", () => {
+    const date = new Date("2024-12-15T13:45:00Z")
     const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("2024-11-01T14:34:15")
+    expect(result).toBe("2024-12-15T13:45")
   })
 
-  it("should handle leap years correctly", () => {
-    const date = new Date("2024-02-29T23:34:15.123Z")
+  it("should handle dates with different time zones correctly", () => {
+    const date = new Date("2024-11-03T01:14:00+09:00")
     const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("2024-02-29T23:34:15")
-  })
-
-  it("should handle dates before 1970 correctly", () => {
-    const date = new Date("1969-12-31T23:34:15.123Z")
-    const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("1969-12-31T23:34:15")
+    expect(result).toBe("2024-11-03T01:14")
   })
 })

--- a/client/src/components/generic/Event/EventUtils.test.ts
+++ b/client/src/components/generic/Event/EventUtils.test.ts
@@ -2,26 +2,14 @@ import { EventRenderingUtils } from "./EventUtils"
 
 describe("dateTimeLocalPlaceHolder", () => {
   it("should format the date correctly in ISO 8601 format without milliseconds", () => {
-    const date = new Date("2024-11-03T01:14:00Z")
+    const date = new Date(2024, 10, 3, 14, 30) // November 3, 2024, 14:30
     const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("2024-11-03T01:14")
+    expect(result).toBe("2024-11-03T14:30")
   })
 
-  it("should pad single digit months, days, hours, and minutes with leading zeros", () => {
-    const date = new Date("2024-01-05T03:09:00Z")
+  it("should pad single digit month, day, hours, and minutes with leading zeros", () => {
+    const date = new Date(2024, 0, 5, 9, 7) // January 5, 2024, 09:07
     const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("2024-01-05T03:09")
-  })
-
-  it("should handle dates with double digit months, days, hours, and minutes correctly", () => {
-    const date = new Date("2024-12-15T13:45:00Z")
-    const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("2024-12-15T13:45")
-  })
-
-  it("should handle dates with different time zones correctly", () => {
-    const date = new Date("2024-11-03T01:14:00+09:00")
-    const result = EventRenderingUtils.dateTimeLocalPlaceHolder(date)
-    expect(result).toBe("2024-11-03T01:14")
+    expect(result).toBe("2024-01-05T09:07")
   })
 })

--- a/client/src/components/generic/Event/EventUtils.ts
+++ b/client/src/components/generic/Event/EventUtils.ts
@@ -100,9 +100,13 @@ export const EventRenderingUtils = {
    * @returns a formatted string in ISO 8601 format without milliseconds
    */
   dateTimeLocalPlaceHolder: (date: Date) => {
-    const isoString = date.toISOString()
-    const placeholderString = isoString.substring(0, isoString.lastIndexOf("."))
-    return placeholderString
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, "0")
+    const day = String(date.getDate()).padStart(2, "0")
+    const hours = String(date.getHours()).padStart(2, "0")
+    const minutes = String(date.getMinutes()).padStart(2, "0")
+
+    return `${year}-${month}-${day}T${hours}:${minutes}`
   },
   /**
    * Utility function to convert a raw {@link Event} into {@link IEventsCardPreview}

--- a/client/src/components/generic/Event/EventUtils.ts
+++ b/client/src/components/generic/Event/EventUtils.ts
@@ -85,6 +85,13 @@ export const EventDateComparisons = {
   }
 } as const
 
+/**
+ * Utility type to allow for a key to to be associated with a preview
+ *
+ * (generally using the firebase `uid`)
+ */
+export type EventCardPreviewWithKey = IEventsCardPreview & { key: string }
+
 export const EventRenderingUtils = {
   /**
    * Generates a placeholder string for a local date and time input field
@@ -109,7 +116,7 @@ export const EventRenderingUtils = {
     eventSetter: (id?: string) => void,
     buttonText?: string,
     variant?: EventCardPreviewVariant
-  ): IEventsCardPreview => {
+  ): EventCardPreviewWithKey => {
     let eventStartDate
 
     if (event.physical_start_date) {
@@ -131,6 +138,7 @@ export const EventRenderingUtils = {
     )
 
     return {
+      key: event.id || event.title,
       date: eventStartDate
         ? EventMessages.eventDateRange(eventStartDate, eventEndDate)
         : "",

--- a/client/src/components/generic/Event/EventUtils.ts
+++ b/client/src/components/generic/Event/EventUtils.ts
@@ -14,6 +14,15 @@ export const IMAGE_PLACEHOLDER_SRC =
  */
 export const EventMessages = {
   /**
+   * Message to be displayed for deleting an event
+   *
+   * @param title the title of the event
+   * @returns a formatted, user-readable string asking for confirmation
+   */
+  adminDeleteEventConfirmation: (title: string) => {
+    return `Are you sure you want to delete the event ${title}? This can NOT be undone!`
+  },
+  /**
    * Message to be displayed for confirming event creation or editing
    *
    * @param isEditing boolean indicating if the event is being edited

--- a/client/src/models/Events.ts
+++ b/client/src/models/Events.ts
@@ -2,4 +2,6 @@ import { components } from "./__generated__/schema"
 
 export type CreateEventBody = components["schemas"]["CreateEventBody"]
 
+export type EditEventBody = components["schemas"]["Partial_Event_"]
+
 export type Event = components["schemas"]["Event"] & { id?: string } // Assume all responses will return an Id

--- a/client/src/services/Admin/AdminMutations.ts
+++ b/client/src/services/Admin/AdminMutations.ts
@@ -10,6 +10,7 @@ import {
 } from "./AdminQueries"
 import { CombinedUserData } from "@/models/User"
 import { replaceUserInPage } from "./AdminUtils"
+import { ALL_EVENTS_QUERY_KEY } from "../Event/EventQueries"
 
 export function usePromoteUserMutation() {
   return useMutation({
@@ -175,8 +176,12 @@ export function useCreateEventMutation() {
   return useMutation({
     mutationKey: ["create-booking"],
     retry: false,
-    mutationFn: AdminService.createEvent
-    // TODO: invalidate all events query (we need to refetch the events)
+    mutationFn: AdminService.createEvent,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ALL_EVENTS_QUERY_KEY]
+      })
+    }
   })
 }
 
@@ -184,6 +189,11 @@ export function useEditEventMutation() {
   return useMutation({
     mutationKey: ["edit-event"],
     retry: false,
-    mutationFn: AdminService.editEvent
+    mutationFn: AdminService.editEvent,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ALL_EVENTS_QUERY_KEY]
+      })
+    }
   })
 }

--- a/client/src/services/Admin/AdminMutations.ts
+++ b/client/src/services/Admin/AdminMutations.ts
@@ -179,3 +179,11 @@ export function useCreateEventMutation() {
     // TODO: invalidate all events query (we need to refetch the events)
   })
 }
+
+export function useEditEventMutation() {
+  return useMutation({
+    mutationKey: ["edit-event"],
+    retry: false,
+    mutationFn: AdminService.editEvent
+  })
+}

--- a/client/src/services/Admin/AdminQueries.ts
+++ b/client/src/services/Admin/AdminQueries.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query"
 import { Timestamp } from "firebase/firestore"
 import AdminService from "./AdminService"
 
@@ -39,5 +39,15 @@ export function useBookingHistoryQuery() {
     retry: 0,
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor
+  })
+}
+
+export function useGetEventQuery() {
+  /**
+   * Need to use this one because we only want a manual trigger
+   */
+  return useMutation({
+    mutationKey: ["single-event"],
+    mutationFn: AdminService.getEvent
   })
 }

--- a/client/src/services/Admin/AdminQueries.ts
+++ b/client/src/services/Admin/AdminQueries.ts
@@ -44,7 +44,8 @@ export function useBookingHistoryQuery() {
 
 export function useGetEventQuery() {
   /**
-   * Need to use this one because we only want a manual trigger
+   * Need to use a mutation instead of query because
+   * we only want a manual trigger of the fetch
    */
   return useMutation({
     mutationKey: ["single-event"],

--- a/client/src/services/Admin/AdminService.ts
+++ b/client/src/services/Admin/AdminService.ts
@@ -2,7 +2,7 @@ import { Timestamp } from "firebase/firestore"
 import { UserAdditionalInfo } from "@/models/User"
 import fetchClient from "@/services/OpenApiFetchClient"
 import { MEMBER_TABLE_MAX_DATA } from "@/utils/Constants"
-import { CreateEventBody } from "@/models/Events"
+import { CreateEventBody, EditEventBody } from "@/models/Events"
 
 export type EditUsersBody = {
   uid: string
@@ -201,6 +201,28 @@ const AdminService = {
 
     if (!response.ok) {
       throw new Error(`Failed to create the event ${data.title}`)
+    }
+  },
+  editEvent: async function ({
+    eventId,
+    newData
+  }: {
+    eventId: string
+    newData: EditEventBody
+  }) {
+    const { response } = await fetchClient.PATCH("/admin/events/{id}", {
+      params: {
+        path: {
+          id: eventId
+        }
+      },
+      body: { ...newData }
+    })
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to edit the event ${newData.title} with id ${eventId}`
+      )
     }
   }
 } as const

--- a/client/src/services/Admin/AdminService.ts
+++ b/client/src/services/Admin/AdminService.ts
@@ -226,7 +226,7 @@ const AdminService = {
     }
   },
   getEvent: async function (eventId: string) {
-    const { response, data } = await fetchClient.GET("/events/{id}", {
+    const { response, data } = await fetchClient.GET("/admin/events/{id}", {
       params: {
         path: { id: eventId }
       }

--- a/client/src/services/Admin/AdminService.ts
+++ b/client/src/services/Admin/AdminService.ts
@@ -224,6 +224,19 @@ const AdminService = {
         `Failed to edit the event ${newData.title} with id ${eventId}`
       )
     }
+  },
+  getEvent: async function (eventId: string) {
+    const { response, data } = await fetchClient.GET("/events/{id}", {
+      params: {
+        path: { id: eventId }
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch data for event with id ${eventId}`)
+    }
+
+    return data?.data
   }
 } as const
 

--- a/client/src/services/Event/EventQueries.ts
+++ b/client/src/services/Event/EventQueries.ts
@@ -1,13 +1,15 @@
 import { useInfiniteQuery } from "@tanstack/react-query"
 import EventService from "./EventService"
 
+export const ALL_EVENTS_QUERY_KEY = "fetch-all-events" as const
+
 /**
  * A paginated query to fetch events (using a wrapper around the {@link EventService})
  */
 export function useLatestEventsQuery() {
   return useInfiniteQuery({
     queryFn: EventService.getAllEvents,
-    queryKey: ["fetch-all-events"],
+    queryKey: [ALL_EVENTS_QUERY_KEY],
     staleTime: 0, // always poll
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor

--- a/server/src/middleware/tests/EventController.test.ts
+++ b/server/src/middleware/tests/EventController.test.ts
@@ -34,7 +34,7 @@ const event3: Event = {
   title: "Another Event",
   location: "Krispy Kreme",
   physical_start_date: laterStartDate,
-  sign_up_start_date: earlierStartDate,
+  sign_up_start_date: laterStartDate,
   sign_up_end_date: earlierStartDate,
   google_forms_link: "https://random.com/event3"
 }

--- a/server/src/service-layer/controllers/EventController.ts
+++ b/server/src/service-layer/controllers/EventController.ts
@@ -28,7 +28,7 @@ export class EventController extends Controller {
       const currentTime = Timestamp.now()
 
       res.events.forEach((event) => {
-        const eventStartTime = event.physical_start_date
+        const eventStartTime = event.sign_up_start_date
         const timeDifference =
           eventStartTime.toMillis() - currentTime.toMillis()
 


### PR DESCRIPTION
Made use of the work in #815, and created the new queries for fetching a single event (waiting for #817) and mutation for editing the event. 

![editevent](https://github.com/user-attachments/assets/53df0899-ece8-4fff-b132-5357a15a2db1)

Have added placeholders for the delete functionality, which an endpoint needs to be made for

Also fixed a logical error in #799 where it was checking the event start date instead of sign up start date