### PR TITLE
Allow events to be deleted on edit view

### DIFF
--- a/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
@@ -57,6 +57,11 @@ interface IAdminEventView {
   handleEditEvent?: (eventId: string, newData: EditEventBody) => void
 
   /**
+   * Callback for when an event is deleted by admin
+   */
+  handleDeleteEvent?: (eventId: string) => void
+
+  /**
    * Obtains the latest data for an event to edit, if `undefined` is passed
    * in then it means that no event should be edited
    */
@@ -74,7 +79,8 @@ const AdminEventViewContent = ({
   fetchMoreEvents,
   handleEditEvent,
   eventPreviousData,
-  fetchEventToEdit
+  fetchEventToEdit,
+  handleDeleteEvent
 }: {
   mode: EventViewModes
   setMode: (mode: EventViewModes) => void
@@ -127,6 +133,10 @@ const AdminEventViewContent = ({
             return await generateImageLink(image)
           }}
           defaultData={eventPreviousData}
+          handleDeleteEvent={async () => {
+            await handleDeleteEvent?.(editedEventId)
+            setMode("view-all-events")
+          }}
           handlePostEvent={async (data) => {
             await handleEditEvent?.(editedEventId, data.data)
             setMode("view-all-events")
@@ -164,7 +174,8 @@ const AdminEventView = ({
   fetchMoreEvents,
   eventPreviousData,
   handleEditEvent,
-  fetchEventToEdit
+  fetchEventToEdit,
+  handleDeleteEvent
 }: IAdminEventView) => {
   const [mode, setMode] = useState<EventViewModes>("view-all-events")
 
@@ -193,10 +204,10 @@ const AdminEventView = ({
           </Button>
         </div>
       </span>
-      {/** TODO: pass in delete handler */}
       <AdminEventViewContent
         setMode={setMode}
         mode={mode}
+        handleDeleteEvent={handleDeleteEvent}
         fetchEventToEdit={fetchEventToEdit}
         handleEditEvent={handleEditEvent}
         handlePostEvent={handlePostEvent}

--- a/client/src/components/composite/Admin/AdminEventView/WrappedAdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/WrappedAdminEventView.tsx
@@ -2,6 +2,7 @@
 
 import {
   useCreateEventMutation,
+  useDeleteEventMutation,
   useEditEventMutation
 } from "@/services/Admin/AdminMutations"
 import AdminEventView from "./AdminEventView"
@@ -24,6 +25,8 @@ const WrappedAdminEventView = () => {
   } = useLatestEventsQuery()
 
   const { mutateAsync: editEvent } = useEditEventMutation()
+
+  const { mutateAsync: deleteEvent } = useDeleteEventMutation()
 
   const [eventPreviousData, setEventPreviousData] = useState<
     Event | undefined
@@ -64,6 +67,7 @@ const WrappedAdminEventView = () => {
         handleEditEvent={async (eventId, newData) => {
           await editEvent({ eventId, newData })
         }}
+        handleDeleteEvent={deleteEvent}
         eventPreviousData={eventPreviousData}
         rawEvents={rawEvents || []}
         hasMoreEvents={hasNextPage}

--- a/client/src/services/Admin/AdminMutations.ts
+++ b/client/src/services/Admin/AdminMutations.ts
@@ -172,16 +172,18 @@ export function useDeleteBookingMutation() {
   })
 }
 
+const invalidateEventsQuery = () => {
+  queryClient.invalidateQueries({
+    queryKey: [ALL_EVENTS_QUERY_KEY]
+  })
+}
+
 export function useCreateEventMutation() {
   return useMutation({
     mutationKey: ["create-booking"],
     retry: false,
     mutationFn: AdminService.createEvent,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [ALL_EVENTS_QUERY_KEY]
-      })
-    }
+    onSuccess: invalidateEventsQuery
   })
 }
 
@@ -190,10 +192,15 @@ export function useEditEventMutation() {
     mutationKey: ["edit-event"],
     retry: false,
     mutationFn: AdminService.editEvent,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [ALL_EVENTS_QUERY_KEY]
-      })
-    }
+    onSuccess: invalidateEventsQuery
+  })
+}
+
+export function useDeleteEventMutation() {
+  return useMutation({
+    mutationKey: ["delete-event"],
+    retry: false,
+    mutationFn: AdminService.deleteEvent,
+    onSuccess: invalidateEventsQuery
   })
 }

--- a/client/src/services/Admin/AdminService.ts
+++ b/client/src/services/Admin/AdminService.ts
@@ -237,6 +237,19 @@ const AdminService = {
     }
 
     return data?.data
+  },
+  deleteEvent: async function (eventId: string) {
+    const { response } = await fetchClient.DELETE("/admin/events/{id}", {
+      params: {
+        path: {
+          id: eventId
+        }
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete event with id ${eventId}`)
+    }
   }
 } as const
 


### PR DESCRIPTION
Now admins have a fully usable events management system!

Made some small code quality changes to invalidate the events queries but otherwise is done. 

![deleteevent](https://github.com/user-attachments/assets/4d954f58-32b5-4d91-baf9-8d5fee7327c9)
