### PR TITLE
Properly refresh the list of events after being refetched

### DIFF
--- a/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventView.tsx
@@ -135,10 +135,12 @@ const AdminEventViewContent = ({
           defaultData={eventPreviousData}
           handleDeleteEvent={async () => {
             await handleDeleteEvent?.(editedEventId)
+            await fetchEventToEdit?.()
             setMode("view-all-events")
           }}
           handlePostEvent={async (data) => {
             await handleEditEvent?.(editedEventId, data.data)
+            await fetchEventToEdit?.()
             setMode("view-all-events")
           }}
           isEditMode

--- a/client/src/services/Admin/AdminMutations.ts
+++ b/client/src/services/Admin/AdminMutations.ts
@@ -172,8 +172,11 @@ export function useDeleteBookingMutation() {
   })
 }
 
+/**
+ * Utility function to refresh the events cache
+ */
 const invalidateEventsQuery = () => {
-  queryClient.invalidateQueries({
+  queryClient.removeQueries({
     queryKey: [ALL_EVENTS_QUERY_KEY]
   })
 }


### PR DESCRIPTION
With this change we now assume that all events are invalid and refetch the whole list, note that this is pretty much the same performance as before anyway - but stops the user from accessing out-of-date data.

![cacheinvalid](https://github.com/user-attachments/assets/a15627d5-759a-47ba-82f1-ce873c044d0a)