### PR TITLE
use a date object for year so that 2024 will not need to be updated

### DIFF
--- a/client/src/app/sections/AboutSection.tsx
+++ b/client/src/app/sections/AboutSection.tsx
@@ -8,7 +8,7 @@ interface IAboutSection {
 
 const DEFAULT_TITLE = "Get ready for the best year of your life!" as const
 const DEFAULT_SUBHEADING =
-  "The University of Auckland Snowsports Club is back again for another banging year, and it's time to lock in your membership for 2024!" as const
+  `The University of Auckland Snowsports Club is back again for another banging year, and it's time to lock in your membership for ${new Date().getFullYear()}!` as const
 const DEFAULT_DESCRIPTION =
   "Whether you're new to the club or an old fart coming back for more, we can't wait to see your pretty face for a year of sending and shredding on and off the slopes!" as const
 

--- a/client/src/components/composite/SignUpForm/Sections/AdditionalSection.tsx
+++ b/client/src/components/composite/SignUpForm/Sections/AdditionalSection.tsx
@@ -89,7 +89,7 @@ export const AdditionalSection = () => {
         value={
           does_racing !== undefined ? (does_racing ? "Yes" : "No") : undefined
         }
-        label="Would you be keen on Racing in 2024?"
+        label={`Would you be keen on Racing in ${new Date().getFullYear()}?`}
         description="All skill levels welcome! Multiple ski races held throughout the season"
         onChange={(e) =>
           updateFormData({ does_racing: e.target?.value === "Yes" })

--- a/client/src/components/composite/SignUpForm/Sections/AdditionalSection.tsx
+++ b/client/src/components/composite/SignUpForm/Sections/AdditionalSection.tsx
@@ -120,7 +120,7 @@ export const AdditionalSection = () => {
 
       <div className="flex flex-col">
         <label htmlFor="hypeLevel">
-          How f#&@g excited are you to SEND IT IN 2024!!!!
+          How f#&@g excited are you to SEND IT IN {new Date().getFullYear()}!!!!
         </label>
         <ExcitementSlider min={0} max={20} />
       </div>


### PR DESCRIPTION
![a0429f74-2819-4227-9066-ca94030b4fba](https://github.com/user-attachments/assets/5cb09a3c-000e-46cc-84ef-70814e6d985c)

Had a problem where it still showed the old year