### PR TITLE
Allow members only events

### DIFF
--- a/client/src/app/events/page.tsx
+++ b/client/src/app/events/page.tsx
@@ -2,6 +2,7 @@
 
 import EventsPage from "@/components/composite/EventsView/EventsView"
 import { useLatestEventsQuery } from "@/services/Event/EventQueries"
+import { useAppData } from "@/store/Store"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
 
@@ -18,6 +19,9 @@ const Events = () => {
   const [preselectedEventId, setPreselectedEventId] = useState<
     string | undefined
   >(params.get(EVENT_QUERY_KEY) || undefined)
+
+  const [{ currentUserClaims }] = useAppData()
+  const isMember = !!currentUserClaims?.member
 
   /**
    * Set the search params (i.e `/events?id={id}`) to the required value
@@ -41,7 +45,8 @@ const Events = () => {
     isFetching,
     fetchNextPage,
     isFetchingNextPage
-  } = useLatestEventsQuery()
+  } = useLatestEventsQuery(isMember)
+
   const rawEvents = useMemo(() => {
     const flattenedEvents = data?.pages.flatMap((page) => {
       return page.data || []
@@ -63,6 +68,7 @@ const Events = () => {
             fetchNextPage()
           }
         }}
+        isMember={isMember}
       />
     </>
   )

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.test.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.test.tsx
@@ -52,6 +52,8 @@ describe("AdminEventForm", () => {
       target: { value: "Test Location" }
     })
 
+    fireEvent.click(getByTestId(AdminEventFormKeys.IS_MEMBERS_ONLY))
+
     fireEvent.click(getByTestId("post-event-button"))
 
     await waitFor(() => {
@@ -60,7 +62,8 @@ describe("AdminEventForm", () => {
           title: "Test Event",
           sign_up_start_date: expect.any(Object),
           physical_start_date: expect.any(Object),
-          location: "Test Location"
+          location: "Test Location",
+          is_members_only: true
         })
       })
     })

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.tsx
@@ -128,10 +128,10 @@ const AdminEventForm = ({
         undefined,
       physical_end_date: physical_end_date
         ? Timestamp.fromDate(
-          new Date(
-            (physical_end_date as string).replace(/-/g, "/").replace("T", " ")
+            new Date(
+              (physical_end_date as string).replace(/-/g, "/").replace("T", " ")
+            )
           )
-        )
         : undefined,
       is_members_only: data.get(AdminEventFormKeys.IS_MEMBERS_ONLY) === "on"
     }
@@ -303,10 +303,12 @@ const AdminEventForm = ({
           type="url"
           label="Google Forms Link"
         />
-        <Checkbox label="Only show sign up link to members?"
+        <Checkbox
+          label="Only show sign up link to members?"
           name={AdminEventFormKeys.IS_MEMBERS_ONLY}
           data-testid={AdminEventFormKeys.IS_MEMBERS_ONLY}
-          defaultChecked={!!defaultData?.is_members_only} />
+          defaultChecked={!!defaultData?.is_members_only}
+        />
         <Button
           disabled={isSubmitting}
           type="submit"

--- a/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/AdminEventForm/AdminEventForm.tsx
@@ -1,3 +1,4 @@
+import Checkbox from "@/components/generic/Checkbox/Checkbox"
 import {
   EventMessages,
   EventRenderingUtils
@@ -74,7 +75,8 @@ export const AdminEventFormKeys = {
   SIGN_UP_END_DATE: "sign up end date",
   PHYSICAL_START_DATE: "physical start date",
   PHYSICAL_END_DATE: "physical end date",
-  MAX_OCCUPANCY: "max signups"
+  MAX_OCCUPANCY: "max signups",
+  IS_MEMBERS_ONLY: "is members only"
 } as const
 
 const Divider = () => <span className="bg-gray-3 my-3 h-[1px] w-full" />
@@ -126,11 +128,12 @@ const AdminEventForm = ({
         undefined,
       physical_end_date: physical_end_date
         ? Timestamp.fromDate(
-            new Date(
-              (physical_end_date as string).replace(/-/g, "/").replace("T", " ")
-            )
+          new Date(
+            (physical_end_date as string).replace(/-/g, "/").replace("T", " ")
           )
-        : undefined
+        )
+        : undefined,
+      is_members_only: data.get(AdminEventFormKeys.IS_MEMBERS_ONLY) === "on"
     }
 
     try {
@@ -300,6 +303,10 @@ const AdminEventForm = ({
           type="url"
           label="Google Forms Link"
         />
+        <Checkbox label="Only show sign up link to members?"
+          name={AdminEventFormKeys.IS_MEMBERS_ONLY}
+          data-testid={AdminEventFormKeys.IS_MEMBERS_ONLY}
+          defaultChecked={!!defaultData?.is_members_only} />
         <Button
           disabled={isSubmitting}
           type="submit"

--- a/client/src/components/composite/Admin/AdminEventView/WrappedAdminEventView.tsx
+++ b/client/src/components/composite/Admin/AdminEventView/WrappedAdminEventView.tsx
@@ -22,7 +22,7 @@ const WrappedAdminEventView = () => {
     isFetching,
     fetchNextPage,
     isFetchingNextPage
-  } = useLatestEventsQuery()
+  } = useLatestEventsQuery(true)
 
   const { mutateAsync: editEvent } = useEditEventMutation()
 

--- a/client/src/components/composite/EventsView/EventsView.tsx
+++ b/client/src/components/composite/EventsView/EventsView.tsx
@@ -49,6 +49,8 @@ interface IEventsPage {
    * @param id - The new selected event ID.
    */
   onSelectedEventIdChange?: (id?: string) => void
+
+  isMember?: boolean
 }
 
 /**
@@ -74,7 +76,8 @@ const EventsPage = ({
   isLoading,
   fetchMoreEvents,
   preselectedEventId,
-  onSelectedEventIdChange
+  onSelectedEventIdChange,
+  isMember
 }: IEventsPage) => {
   const [selectedEventId, setSelectedEventId] = useState<string | undefined>(
     preselectedEventId
@@ -99,7 +102,7 @@ const EventsPage = ({
           EventDateComparisons.isPastEvent(
             new Date(DateUtils.timestampMilliseconds(physical_start_date)),
             physical_end_date &&
-              new Date(DateUtils.timestampMilliseconds(physical_end_date))
+            new Date(DateUtils.timestampMilliseconds(physical_end_date))
           )
         ) {
           buf.pastEvents.push(event)
@@ -164,7 +167,8 @@ const EventsPage = ({
       physical_end_date,
       physical_start_date,
       description,
-      title
+      title,
+      is_members_only
     } = selectedEventObject
     return (
       <EventDetailed
@@ -174,12 +178,12 @@ const EventsPage = ({
         date={EventMessages.eventDateRange(
           new Date(DateUtils.timestampMilliseconds(physical_start_date)),
           physical_end_date &&
-            new Date(DateUtils.timestampMilliseconds(physical_end_date))
+          new Date(DateUtils.timestampMilliseconds(physical_end_date))
         )}
         isPastEvent={EventDateComparisons.isPastEvent(
           new Date(DateUtils.timestampMilliseconds(physical_start_date)),
           physical_end_date &&
-            new Date(DateUtils.timestampMilliseconds(physical_end_date))
+          new Date(DateUtils.timestampMilliseconds(physical_end_date))
         )}
         image={selectedEventObject.image_url || IMAGE_PLACEHOLDER_SRC}
         location={selectedEventObject.location}
@@ -189,9 +193,11 @@ const EventsPage = ({
         googleFormLink={google_forms_link}
         content={<p>{description}</p>}
         title={title}
+        hasSignUpRights={!is_members_only || isMember}
+        isMembersOnly={is_members_only}
       />
     )
-  }, [selectedEventObject, eventSelectionHandler])
+  }, [selectedEventObject, eventSelectionHandler, isMember])
 
   const previewCurrentEvents =
     eventList.upcomingAndCurrentEvents?.map((event) => {

--- a/client/src/components/composite/EventsView/EventsView.tsx
+++ b/client/src/components/composite/EventsView/EventsView.tsx
@@ -102,7 +102,7 @@ const EventsPage = ({
           EventDateComparisons.isPastEvent(
             new Date(DateUtils.timestampMilliseconds(physical_start_date)),
             physical_end_date &&
-            new Date(DateUtils.timestampMilliseconds(physical_end_date))
+              new Date(DateUtils.timestampMilliseconds(physical_end_date))
           )
         ) {
           buf.pastEvents.push(event)
@@ -178,12 +178,12 @@ const EventsPage = ({
         date={EventMessages.eventDateRange(
           new Date(DateUtils.timestampMilliseconds(physical_start_date)),
           physical_end_date &&
-          new Date(DateUtils.timestampMilliseconds(physical_end_date))
+            new Date(DateUtils.timestampMilliseconds(physical_end_date))
         )}
         isPastEvent={EventDateComparisons.isPastEvent(
           new Date(DateUtils.timestampMilliseconds(physical_start_date)),
           physical_end_date &&
-          new Date(DateUtils.timestampMilliseconds(physical_end_date))
+            new Date(DateUtils.timestampMilliseconds(physical_end_date))
         )}
         image={selectedEventObject.image_url || IMAGE_PLACEHOLDER_SRC}
         location={selectedEventObject.location}

--- a/client/src/components/generic/Event/EventDetailed/EventDetailed.tsx
+++ b/client/src/components/generic/Event/EventDetailed/EventDetailed.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image"
+import { MembersOnlyMessage } from "../EventUtils/EventUtils"
 /**
  * Props for event card
  */
@@ -52,7 +53,13 @@ export interface IEventDetailed {
   /**
    * The image cover on the top of the card
    */
-  image: string
+  image: string,
+
+  /**
+   * If the event permits the current user to have access to sign up
+   */
+  hasSignUpRights?: boolean
+  isMembersOnly?: boolean
 }
 
 /**
@@ -69,8 +76,11 @@ const EventDetailed = ({
   image,
   signUpOpenDate,
   googleFormLink,
-  isPastEvent
+  isPastEvent,
+  hasSignUpRights,
+  isMembersOnly
 }: IEventDetailed) => {
+
   const Divider = () => {
     return <div className="bg-gray-3 mb-4 mt-4 h-[1px] w-full"></div>
   }
@@ -90,7 +100,7 @@ const EventDetailed = ({
             </h5>
           )}
           <h5 className={`font-bold ${isPastEvent && "line-through"}`}>
-            {date}
+            {date} <MembersOnlyMessage isMembersOnly={!!isMembersOnly} />
           </h5>
 
           <h3 className="text-dark-blue-100 mt-1 font-bold">{title}</h3>
@@ -99,8 +109,7 @@ const EventDetailed = ({
 
           <div className="flex flex-col gap-4">
             <div className="whitespace-pre-line text-left">{content}</div>
-
-            {signUpOpenDate &&
+            {hasSignUpRights ? <>{signUpOpenDate &&
               !isPastEvent &&
               googleFormLink &&
               (signUpOpenDate <= new Date() ? (
@@ -111,7 +120,7 @@ const EventDetailed = ({
                       CLICK ME TO GO TO FORM
                     </a>
                   </h5>
-                  <iframe height={"500"} src={googleFormLink} />
+                  <iframe height={"500"} src={googleFormLink} title="Google Forms Sign Up" />
                 </>
               ) : (
                 <>
@@ -119,7 +128,9 @@ const EventDetailed = ({
                     Sign ups open at {signUpOpenDate.toLocaleString()}
                   </h5>
                 </>
-              ))}
+              ))}</> :
+              <h5 className="text-dark-blue-100 font-bold">Members Only Event {" - "}
+                <a href="/register" className="underline text-light-blue-100">Become a member</a></h5>}
           </div>
         </div>
 

--- a/client/src/components/generic/Event/EventDetailed/EventDetailed.tsx
+++ b/client/src/components/generic/Event/EventDetailed/EventDetailed.tsx
@@ -53,7 +53,7 @@ export interface IEventDetailed {
   /**
    * The image cover on the top of the card
    */
-  image: string,
+  image: string
 
   /**
    * If the event permits the current user to have access to sign up
@@ -80,7 +80,6 @@ const EventDetailed = ({
   hasSignUpRights,
   isMembersOnly
 }: IEventDetailed) => {
-
   const Divider = () => {
     return <div className="bg-gray-3 mb-4 mt-4 h-[1px] w-full"></div>
   }
@@ -109,28 +108,45 @@ const EventDetailed = ({
 
           <div className="flex flex-col gap-4">
             <div className="whitespace-pre-line text-left">{content}</div>
-            {hasSignUpRights ? <>{signUpOpenDate &&
-              !isPastEvent &&
-              googleFormLink &&
-              (signUpOpenDate <= new Date() ? (
-                <>
-                  <h5 className="font-bold uppercase">Sign Ups Open!</h5>
-                  <h5 className="text-dark-blue-100 font-bold uppercase italic">
-                    <a href={googleFormLink} target="_blank" rel="noreferrer">
-                      CLICK ME TO GO TO FORM
-                    </a>
-                  </h5>
-                  <iframe height={"500"} src={googleFormLink} title="Google Forms Sign Up" />
-                </>
-              ) : (
-                <>
-                  <h5 className="font-bold">
-                    Sign ups open at {signUpOpenDate.toLocaleString()}
-                  </h5>
-                </>
-              ))}</> :
-              <h5 className="text-dark-blue-100 font-bold">Members Only Event {" - "}
-                <a href="/register" className="underline text-light-blue-100">Become a member</a></h5>}
+            {hasSignUpRights ? (
+              <>
+                {signUpOpenDate &&
+                  !isPastEvent &&
+                  googleFormLink &&
+                  (signUpOpenDate <= new Date() ? (
+                    <>
+                      <h5 className="font-bold uppercase">Sign Ups Open!</h5>
+                      <h5 className="text-dark-blue-100 font-bold uppercase italic">
+                        <a
+                          href={googleFormLink}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          CLICK ME TO GO TO FORM
+                        </a>
+                      </h5>
+                      <iframe
+                        height={"500"}
+                        src={googleFormLink}
+                        title="Google Forms Sign Up"
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <h5 className="font-bold">
+                        Sign ups open at {signUpOpenDate.toLocaleString()}
+                      </h5>
+                    </>
+                  ))}
+              </>
+            ) : (
+              <h5 className="text-dark-blue-100 font-bold">
+                Members Only Event {" - "}
+                <a href="/register" className="text-light-blue-100 underline">
+                  Become a member
+                </a>
+              </h5>
+            )}
           </div>
         </div>
 

--- a/client/src/components/generic/Event/EventPreview/EventPreview.tsx
+++ b/client/src/components/generic/Event/EventPreview/EventPreview.tsx
@@ -39,7 +39,7 @@ export interface IEventsCardPreview {
   /**
    * The text to display on the view button
    */
-  viewButtonText?: string,
+  viewButtonText?: string
 
   /**
    * If the event is members only
@@ -105,7 +105,10 @@ const EventsCardPreview = ({
       </div>
       <div className="mb-4 flex flex-col sm:ml-4 ">
         <div>
-          <h5 className=" text-sm font-bold">{date}<MembersOnlyMessage isMembersOnly={!!isMembersOnly} /></h5>
+          <h5 className=" text-sm font-bold">
+            {date}
+            <MembersOnlyMessage isMembersOnly={!!isMembersOnly} />
+          </h5>
           <p className="text-gray-4 pt-1 text-lg">
             {isPastEvent
               ? "Event has ended."

--- a/client/src/components/generic/Event/EventPreview/EventPreview.tsx
+++ b/client/src/components/generic/Event/EventPreview/EventPreview.tsx
@@ -1,6 +1,7 @@
 // 4 props: 3 string, 1 image
 import Image from "next/image"
 import Arrow from "@/assets/icons/rightarrow.svg"
+import { MembersOnlyMessage } from "../EventUtils/EventUtils"
 export type EventCardPreviewVariant = "regular" | "admin"
 /**
  * The interface (props) associated with {@link EventsCardPreview}
@@ -38,7 +39,13 @@ export interface IEventsCardPreview {
   /**
    * The text to display on the view button
    */
-  viewButtonText?: string
+  viewButtonText?: string,
+
+  /**
+   * If the event is members only
+   */
+  isMembersOnly?: boolean
+
   /**
    * The variant of the card to render
    */
@@ -77,6 +84,7 @@ const EventsCardPreview = ({
   image = "",
   signUpOpenDate,
   isPastEvent,
+  isMembersOnly,
   viewButtonText = "view more",
   variant = "regular"
 }: IEventsCardPreview) => {
@@ -97,7 +105,7 @@ const EventsCardPreview = ({
       </div>
       <div className="mb-4 flex flex-col sm:ml-4 ">
         <div>
-          <h5 className=" text-sm font-bold">{date}</h5>
+          <h5 className=" text-sm font-bold">{date}<MembersOnlyMessage isMembersOnly={!!isMembersOnly} /></h5>
           <p className="text-gray-4 pt-1 text-lg">
             {isPastEvent
               ? "Event has ended."

--- a/client/src/components/generic/Event/EventUtils.ts
+++ b/client/src/components/generic/Event/EventUtils.ts
@@ -167,6 +167,7 @@ export const EventRenderingUtils = {
         eventSetter(event.id)
       },
       viewButtonText: buttonText,
+      isMembersOnly: event.is_members_only,
       variant
     }
   }

--- a/client/src/components/generic/Event/EventUtils/EventUtils.tsx
+++ b/client/src/components/generic/Event/EventUtils/EventUtils.tsx
@@ -1,7 +1,9 @@
 interface IMembersOnlyMessage {
-    isMembersOnly: boolean
+  isMembersOnly: boolean
 }
 
 export const MembersOnlyMessage = ({ isMembersOnly }: IMembersOnlyMessage) => {
-    return isMembersOnly ? <span className="text-light-blue-100"> - Members Only!</span> : null
+  return isMembersOnly ? (
+    <span className="text-light-blue-100"> - Members Only!</span>
+  ) : null
 }

--- a/client/src/components/generic/Event/EventUtils/EventUtils.tsx
+++ b/client/src/components/generic/Event/EventUtils/EventUtils.tsx
@@ -1,0 +1,7 @@
+interface IMembersOnlyMessage {
+    isMembersOnly: boolean
+}
+
+export const MembersOnlyMessage = ({ isMembersOnly }: IMembersOnlyMessage) => {
+    return isMembersOnly ? <span className="text-light-blue-100"> - Members Only!</span> : null
+}

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -62,7 +62,10 @@ export interface paths {
   "/events/for-members": {
     /**
      * @description Fetches latest events starting from the event with the latest starting date
-     * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+     * (**NOT** the signup open date) based on limit. Is paginated with a cursor.
+     *
+     * This endpoint is only accessible to members as it includes the sign up links
+     * members-only events
      */
     get: operations["GetAllEventsAsMember"];
   };
@@ -968,7 +971,10 @@ export interface operations {
   };
   /**
    * @description Fetches latest events starting from the event with the latest starting date
-   * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+   * (**NOT** the signup open date) based on limit. Is paginated with a cursor.
+   *
+   * This endpoint is only accessible to members as it includes the sign up links
+   * members-only events
    */
   GetAllEventsAsMember: {
     parameters: {

--- a/client/src/models/__generated__/schema.d.ts
+++ b/client/src/models/__generated__/schema.d.ts
@@ -59,6 +59,13 @@ export interface paths {
      */
     get: operations["GetAllEvents"];
   };
+  "/events/for-members": {
+    /**
+     * @description Fetches latest events starting from the event with the latest starting date
+     * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+     */
+    get: operations["GetAllEventsAsMember"];
+  };
   "/bookings": {
     /** @description Fetches all bookings for a user based on their UID. */
     get: operations["GetAllBookings"];
@@ -347,6 +354,8 @@ export interface components {
        * @example 30
        */
       max_occupancy?: number;
+      /** @description If `true` then only members should see the sign up link */
+      is_members_only?: boolean;
     };
     DocumentDataWithUid_Event_: components["schemas"]["Event"] & {
       /** @description The ID of the document for which this document contains data. */
@@ -737,6 +746,8 @@ export interface components {
        * @example 30
        */
       max_occupancy?: number;
+      /** @description If `true` then only members should see the sign up link */
+      is_members_only?: boolean;
     };
     GetEventResponse: {
       error?: string;
@@ -940,6 +951,26 @@ export interface operations {
    * (**NOT** the signup open date) based on limit. Is paginated with a cursor
    */
   GetAllEvents: {
+    parameters: {
+      query?: {
+        limit?: number;
+        cursor?: string;
+      };
+    };
+    responses: {
+      /** @description Successfully fetched all events */
+      200: {
+        content: {
+          "application/json": components["schemas"]["GetAllEventsResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * @description Fetches latest events starting from the event with the latest starting date
+   * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+   */
+  GetAllEventsAsMember: {
     parameters: {
       query?: {
         limit?: number;

--- a/client/src/services/Event/EventQueries.ts
+++ b/client/src/services/Event/EventQueries.ts
@@ -6,10 +6,12 @@ export const ALL_EVENTS_QUERY_KEY = "fetch-all-events" as const
 /**
  * A paginated query to fetch events (using a wrapper around the {@link EventService})
  */
-export function useLatestEventsQuery() {
+export function useLatestEventsQuery(isMember: boolean) {
   return useInfiniteQuery({
-    queryFn: EventService.getAllEvents,
-    queryKey: [ALL_EVENTS_QUERY_KEY],
+    queryFn: isMember
+      ? EventService.getAllEventsAsMember
+      : EventService.getAllEvents,
+    queryKey: [ALL_EVENTS_QUERY_KEY, isMember],
     staleTime: 0, // always poll
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor

--- a/client/src/services/Event/EventService.ts
+++ b/client/src/services/Event/EventService.ts
@@ -16,6 +16,22 @@ const EventService = {
     }
 
     return data
+  },
+  getAllEventsAsMember: async function ({ pageParam }: { pageParam?: string }) {
+    const { data, response } = await fetchClient.GET("/events/for-members", {
+      params: {
+        query: {
+          limit: 15,
+          cursor: pageParam
+        }
+      }
+    })
+
+    if (!response.ok || !data) {
+      throw new Error("Failed to fetch all events")
+    }
+
+    return data
   }
 } as const
 

--- a/server/src/data-layer/models/firebase.ts
+++ b/server/src/data-layer/models/firebase.ts
@@ -188,6 +188,11 @@ export interface Event {
    * @example 30
    */
   max_occupancy?: number
+
+  /**
+   * If `true` then only members should see the sign up link
+   */
+  is_members_only?: boolean
 }
 
 /**

--- a/server/src/middleware/__generated__/routes.ts
+++ b/server/src/middleware/__generated__/routes.ts
@@ -193,6 +193,7 @@ const models: TsoaRoute.Models = {
             "physical_start_date": {"ref":"FirebaseFirestore.Timestamp","required":true},
             "physical_end_date": {"ref":"FirebaseFirestore.Timestamp"},
             "max_occupancy": {"dataType":"double"},
+            "is_members_only": {"dataType":"boolean"},
         },
         "additionalProperties": false,
     },
@@ -545,7 +546,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_Event_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"description":{"dataType":"string"},"image_url":{"dataType":"string"},"location":{"dataType":"string"},"google_forms_link":{"dataType":"string"},"sign_up_start_date":{"ref":"FirebaseFirestore.Timestamp"},"sign_up_end_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_start_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_end_date":{"ref":"FirebaseFirestore.Timestamp"},"max_occupancy":{"dataType":"double"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"description":{"dataType":"string"},"image_url":{"dataType":"string"},"location":{"dataType":"string"},"google_forms_link":{"dataType":"string"},"sign_up_start_date":{"ref":"FirebaseFirestore.Timestamp"},"sign_up_end_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_start_date":{"ref":"FirebaseFirestore.Timestamp"},"physical_end_date":{"ref":"FirebaseFirestore.Timestamp"},"max_occupancy":{"dataType":"double"},"is_members_only":{"dataType":"boolean"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "GetEventResponse": {
@@ -895,6 +896,38 @@ export function RegisterRoutes(app: Router) {
 
               templateService.apiHandler({
                 methodName: 'getAllEvents',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/events/for-members',
+            authenticateMiddleware([{"jwt":["member"]}]),
+            ...(fetchMiddlewares<RequestHandler>(EventController)),
+            ...(fetchMiddlewares<RequestHandler>(EventController.prototype.getAllEventsAsMember)),
+
+            function EventController_getAllEventsAsMember(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    limit: {"default":20,"in":"query","name":"limit","dataType":"double"},
+                    cursor: {"in":"query","name":"cursor","dataType":"string"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new EventController();
+
+              templateService.apiHandler({
+                methodName: 'getAllEventsAsMember',
                 controller,
                 response,
                 next,

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -403,7 +403,7 @@
 					},
 					"description": {
 						"type": "string",
-						"description": "An optional description for this event\nThis should be in markdown"
+						"description": "An optional description for this event\r\nThis should be in markdown"
 					},
 					"image_url": {
 						"type": "string",
@@ -415,23 +415,23 @@
 					},
 					"google_forms_link": {
 						"type": "string",
-						"description": "A URL to the google form for signing up to the event. This is not to be included\nin any response body unless we are _near_ the period for sign up"
+						"description": "A URL to the google form for signing up to the event. This is not to be included\r\nin any response body unless we are _near_ the period for sign up"
 					},
 					"sign_up_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "The signup period start date.\nNote that this date is in UTC time.\nUse the same start and end date to indicate a 1 day signup period."
+						"description": "The signup period start date.\r\nNote that this date is in UTC time.\r\nUse the same start and end date to indicate a 1 day signup period."
 					},
 					"sign_up_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "The signup period end date.\nNote that this date is in UTC time."
+						"description": "The signup period end date.\r\nNote that this date is in UTC time."
 					},
 					"physical_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event start date for the event i.e the day members should meet at shads,\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
+						"description": "Event start date for the event i.e the day members should meet at shads,\r\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
 					},
 					"physical_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event end time for the event i.e the last day members will be at the lodge,\nis optionial in case of one day events. **NOT** the signups, refer to\n{@link sign_up_end_date} for signup end date"
+						"description": "Event end time for the event i.e the last day members will be at the lodge,\r\nis optionial in case of one day events. **NOT** the signups, refer to\r\n{@link sign_up_end_date} for signup end date"
 					},
 					"max_occupancy": {
 						"type": "number",
@@ -481,7 +481,7 @@
 					},
 					"nextCursor": {
 						"type": "string",
-						"description": "Needed for firestore operations which do not support offset\nbased pagination\n\n**Will be undefined in case of last page**"
+						"description": "Needed for firestore operations which do not support offset\r\nbased pagination\r\n\r\n**Will be undefined in case of last page**"
 					},
 					"data": {
 						"items": {
@@ -966,7 +966,7 @@
 					},
 					"nextCursor": {
 						"type": "string",
-						"description": "Needed for firestore operations which do not support offset\nbased pagination\n\n**Will be undefined in case of last page**"
+						"description": "Needed for firestore operations which do not support offset\r\nbased pagination\r\n\r\n**Will be undefined in case of last page**"
 					},
 					"data": {
 						"items": {
@@ -1221,7 +1221,7 @@
 							"added_user_to_booking"
 						],
 						"nullable": false,
-						"description": "The type of event that the admin performed, used for parsing on the front-end\n\nEach of these are associated with the following:\n\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
+						"description": "The type of event that the admin performed, used for parsing on the front-end\r\n\r\nEach of these are associated with the following:\r\n\r\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\r\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\r\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
 					},
 					"uid": {
 						"type": "string",
@@ -1259,7 +1259,7 @@
 							"removed_user_from_booking"
 						],
 						"nullable": false,
-						"description": "The type of event that the admin performed, used for parsing on the front-end\n\nEach of these are associated with the following:\n\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
+						"description": "The type of event that the admin performed, used for parsing on the front-end\r\n\r\nEach of these are associated with the following:\r\n\r\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\r\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\r\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
 					},
 					"uid": {
 						"type": "string",
@@ -1297,12 +1297,12 @@
 							"changed_date_availability"
 						],
 						"nullable": false,
-						"description": "The type of event that the admin performed, used for parsing on the front-end\n\nEach of these are associated with the following:\n\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
+						"description": "The type of event that the admin performed, used for parsing on the front-end\r\n\r\nEach of these are associated with the following:\r\n\r\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\r\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\r\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
 					},
 					"change": {
 						"type": "number",
 						"format": "double",
-						"description": "The **signed** difference between the newly available slots and the previously available slots.\n\nFor example, if the original available slots was 32, and the availability was set to 0,\nthe `change` in the slots needs to be **0 - 32 = -32**\n\nAnd vice versa, if the original available slots was 16, and the availability was set to 32,\nthe `change` would be **32 - 16 = 16**"
+						"description": "The **signed** difference between the newly available slots and the previously available slots.\r\n\r\nFor example, if the original available slots was 32, and the availability was set to 0,\r\nthe `change` in the slots needs to be **0 - 32 = -32**\r\n\r\nAnd vice versa, if the original available slots was 16, and the availability was set to 32,\r\nthe `change` would be **32 - 16 = 16**"
 					}
 				},
 				"required": [
@@ -1333,7 +1333,7 @@
 				"properties": {
 					"nextCursor": {
 						"type": "string",
-						"description": "Needed for firestore operations which do not support offset\nbased pagination\n\n**Will be undefined in case of last page**"
+						"description": "Needed for firestore operations which do not support offset\r\nbased pagination\r\n\r\n**Will be undefined in case of last page**"
 					},
 					"error": {
 						"type": "string"
@@ -1371,7 +1371,7 @@
 					},
 					"description": {
 						"type": "string",
-						"description": "An optional description for this event\nThis should be in markdown"
+						"description": "An optional description for this event\r\nThis should be in markdown"
 					},
 					"image_url": {
 						"type": "string",
@@ -1383,23 +1383,23 @@
 					},
 					"google_forms_link": {
 						"type": "string",
-						"description": "A URL to the google form for signing up to the event. This is not to be included\nin any response body unless we are _near_ the period for sign up"
+						"description": "A URL to the google form for signing up to the event. This is not to be included\r\nin any response body unless we are _near_ the period for sign up"
 					},
 					"sign_up_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "The signup period start date.\nNote that this date is in UTC time.\nUse the same start and end date to indicate a 1 day signup period."
+						"description": "The signup period start date.\r\nNote that this date is in UTC time.\r\nUse the same start and end date to indicate a 1 day signup period."
 					},
 					"sign_up_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "The signup period end date.\nNote that this date is in UTC time."
+						"description": "The signup period end date.\r\nNote that this date is in UTC time."
 					},
 					"physical_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event start date for the event i.e the day members should meet at shads,\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
+						"description": "Event start date for the event i.e the day members should meet at shads,\r\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
 					},
 					"physical_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event end time for the event i.e the last day members will be at the lodge,\nis optionial in case of one day events. **NOT** the signups, refer to\n{@link sign_up_end_date} for signup end date"
+						"description": "Event end time for the event i.e the last day members will be at the lodge,\r\nis optionial in case of one day events. **NOT** the signups, refer to\r\n{@link sign_up_end_date} for signup end date"
 					},
 					"max_occupancy": {
 						"type": "number",
@@ -1611,7 +1611,7 @@
 						"description": "Webhook post received"
 					}
 				},
-				"description": "Webhook endpoint for Stripe events.\nThis single endpoint is setup in the Stripe developer config to handle various events.",
+				"description": "Webhook endpoint for Stripe events.\r\nThis single endpoint is setup in the Stripe developer config to handle various events.",
 				"security": [],
 				"parameters": []
 			}
@@ -1794,7 +1794,7 @@
 						}
 					}
 				},
-				"description": "Creates a new booking session for the date ranges passed in,\nwill return any existing sessions if they have been started in\nthe last 30 minutes (the minimum period stripe has to persist a session for)",
+				"description": "Creates a new booking session for the date ranges passed in,\r\nwill return any existing sessions if they have been started in\r\nthe last 30 minutes (the minimum period stripe has to persist a session for)",
 				"security": [
 					{
 						"jwt": [
@@ -1832,7 +1832,7 @@
 						}
 					}
 				},
-				"description": "Fetches latest events starting from the event with the latest starting date\n(**NOT** the signup open date) based on limit. Is paginated with a cursor",
+				"description": "Fetches latest events starting from the event with the latest starting date\r\n(**NOT** the signup open date) based on limit. Is paginated with a cursor",
 				"security": [],
 				"parameters": [
 					{
@@ -1871,7 +1871,7 @@
 						}
 					}
 				},
-				"description": "Fetches latest events starting from the event with the latest starting date\n(**NOT** the signup open date) based on limit. Is paginated with a cursor",
+				"description": "Fetches latest events starting from the event with the latest starting date\r\n(**NOT** the signup open date) based on limit. Is paginated with a cursor.\r\n\r\nThis endpoint is only accessible to members as it includes the sign up links\r\nmembers-only events",
 				"security": [
 					{
 						"jwt": [
@@ -1980,7 +1980,7 @@
 						}
 					}
 				},
-				"description": "This method fetches users based on a booking date range.\nThis method requires an admin JWT token.",
+				"description": "This method fetches users based on a booking date range.\r\nThis method requires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2216,7 +2216,7 @@
 						}
 					}
 				},
-				"description": "Get a user by their UID.\nRequires an admin JWT token.",
+				"description": "Get a user by their UID.\r\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2245,7 +2245,7 @@
 						"description": "Created"
 					}
 				},
-				"description": "Adds a new user to the database with their UID and user data.\nRequires an admin JWT token.",
+				"description": "Adds a new user to the database with their UID and user data.\r\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2276,7 +2276,7 @@
 						"description": "Edited"
 					}
 				},
-				"description": "Edits a list of users with updated user additional info.\nRequires an admin JWT token.",
+				"description": "Edits a list of users with updated user additional info.\r\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2307,7 +2307,7 @@
 						"description": "Promoted user"
 					}
 				},
-				"description": "Promotes a user to a member. This returns a conflict when the user is already a member.\nRequires an admin JWT token.",
+				"description": "Promotes a user to a member. This returns a conflict when the user is already a member.\r\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2338,7 +2338,7 @@
 						"description": "Demoted user"
 					}
 				},
-				"description": "Demotes a member to a guest. This returns a conflict when the user is already a guest.\nRequires an admin JWT token.",
+				"description": "Demotes a member to a guest. This returns a conflict when the user is already a guest.\r\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2369,7 +2369,7 @@
 						"description": "Demoted all non-admin users"
 					}
 				},
-				"description": "Demotes all non-admin users to guests. This is used to purge all membership statuses at the end of a billing cycle.\nRequires an admin JWT token.",
+				"description": "Demotes all non-admin users to guests. This is used to purge all membership statuses at the end of a billing cycle.\r\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2388,7 +2388,7 @@
 						"description": "Coupon Added"
 					}
 				},
-				"description": "Adds a coupon to a user's stripe id.\nRequires an admin JWT token.",
+				"description": "Adds a coupon to a user's stripe id.\r\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -403,7 +403,7 @@
 					},
 					"description": {
 						"type": "string",
-						"description": "An optional description for this event\r\nThis should be in markdown"
+						"description": "An optional description for this event\nThis should be in markdown"
 					},
 					"image_url": {
 						"type": "string",
@@ -415,23 +415,23 @@
 					},
 					"google_forms_link": {
 						"type": "string",
-						"description": "A URL to the google form for signing up to the event. This is not to be included\r\nin any response body unless we are _near_ the period for sign up"
+						"description": "A URL to the google form for signing up to the event. This is not to be included\nin any response body unless we are _near_ the period for sign up"
 					},
 					"sign_up_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "The signup period start date.\r\nNote that this date is in UTC time.\r\nUse the same start and end date to indicate a 1 day signup period."
+						"description": "The signup period start date.\nNote that this date is in UTC time.\nUse the same start and end date to indicate a 1 day signup period."
 					},
 					"sign_up_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "The signup period end date.\r\nNote that this date is in UTC time."
+						"description": "The signup period end date.\nNote that this date is in UTC time."
 					},
 					"physical_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event start date for the event i.e the day members should meet at shads,\r\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
+						"description": "Event start date for the event i.e the day members should meet at shads,\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
 					},
 					"physical_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event end time for the event i.e the last day members will be at the lodge,\r\nis optionial in case of one day events. **NOT** the signups, refer to\r\n{@link sign_up_end_date} for signup end date"
+						"description": "Event end time for the event i.e the last day members will be at the lodge,\nis optionial in case of one day events. **NOT** the signups, refer to\n{@link sign_up_end_date} for signup end date"
 					},
 					"max_occupancy": {
 						"type": "number",
@@ -481,7 +481,7 @@
 					},
 					"nextCursor": {
 						"type": "string",
-						"description": "Needed for firestore operations which do not support offset\r\nbased pagination\r\n\r\n**Will be undefined in case of last page**"
+						"description": "Needed for firestore operations which do not support offset\nbased pagination\n\n**Will be undefined in case of last page**"
 					},
 					"data": {
 						"items": {
@@ -966,7 +966,7 @@
 					},
 					"nextCursor": {
 						"type": "string",
-						"description": "Needed for firestore operations which do not support offset\r\nbased pagination\r\n\r\n**Will be undefined in case of last page**"
+						"description": "Needed for firestore operations which do not support offset\nbased pagination\n\n**Will be undefined in case of last page**"
 					},
 					"data": {
 						"items": {
@@ -1221,7 +1221,7 @@
 							"added_user_to_booking"
 						],
 						"nullable": false,
-						"description": "The type of event that the admin performed, used for parsing on the front-end\r\n\r\nEach of these are associated with the following:\r\n\r\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\r\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\r\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
+						"description": "The type of event that the admin performed, used for parsing on the front-end\n\nEach of these are associated with the following:\n\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
 					},
 					"uid": {
 						"type": "string",
@@ -1259,7 +1259,7 @@
 							"removed_user_from_booking"
 						],
 						"nullable": false,
-						"description": "The type of event that the admin performed, used for parsing on the front-end\r\n\r\nEach of these are associated with the following:\r\n\r\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\r\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\r\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
+						"description": "The type of event that the admin performed, used for parsing on the front-end\n\nEach of these are associated with the following:\n\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
 					},
 					"uid": {
 						"type": "string",
@@ -1297,12 +1297,12 @@
 							"changed_date_availability"
 						],
 						"nullable": false,
-						"description": "The type of event that the admin performed, used for parsing on the front-end\r\n\r\nEach of these are associated with the following:\r\n\r\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\r\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\r\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
+						"description": "The type of event that the admin performed, used for parsing on the front-end\n\nEach of these are associated with the following:\n\n- `\"added_user_to_booking\"`: {@link BookingAddedEvent}\n- `\"removed_user_from_booking\"`: {@link BookingDeletedEvent}\n- `\"changed_date_availability\"`: {@link BookingAvailabilityChangeEvent}"
 					},
 					"change": {
 						"type": "number",
 						"format": "double",
-						"description": "The **signed** difference between the newly available slots and the previously available slots.\r\n\r\nFor example, if the original available slots was 32, and the availability was set to 0,\r\nthe `change` in the slots needs to be **0 - 32 = -32**\r\n\r\nAnd vice versa, if the original available slots was 16, and the availability was set to 32,\r\nthe `change` would be **32 - 16 = 16**"
+						"description": "The **signed** difference between the newly available slots and the previously available slots.\n\nFor example, if the original available slots was 32, and the availability was set to 0,\nthe `change` in the slots needs to be **0 - 32 = -32**\n\nAnd vice versa, if the original available slots was 16, and the availability was set to 32,\nthe `change` would be **32 - 16 = 16**"
 					}
 				},
 				"required": [
@@ -1333,7 +1333,7 @@
 				"properties": {
 					"nextCursor": {
 						"type": "string",
-						"description": "Needed for firestore operations which do not support offset\r\nbased pagination\r\n\r\n**Will be undefined in case of last page**"
+						"description": "Needed for firestore operations which do not support offset\nbased pagination\n\n**Will be undefined in case of last page**"
 					},
 					"error": {
 						"type": "string"
@@ -1371,7 +1371,7 @@
 					},
 					"description": {
 						"type": "string",
-						"description": "An optional description for this event\r\nThis should be in markdown"
+						"description": "An optional description for this event\nThis should be in markdown"
 					},
 					"image_url": {
 						"type": "string",
@@ -1383,23 +1383,23 @@
 					},
 					"google_forms_link": {
 						"type": "string",
-						"description": "A URL to the google form for signing up to the event. This is not to be included\r\nin any response body unless we are _near_ the period for sign up"
+						"description": "A URL to the google form for signing up to the event. This is not to be included\nin any response body unless we are _near_ the period for sign up"
 					},
 					"sign_up_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "The signup period start date.\r\nNote that this date is in UTC time.\r\nUse the same start and end date to indicate a 1 day signup period."
+						"description": "The signup period start date.\nNote that this date is in UTC time.\nUse the same start and end date to indicate a 1 day signup period."
 					},
 					"sign_up_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "The signup period end date.\r\nNote that this date is in UTC time."
+						"description": "The signup period end date.\nNote that this date is in UTC time."
 					},
 					"physical_start_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event start date for the event i.e the day members should meet at shads,\r\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
+						"description": "Event start date for the event i.e the day members should meet at shads,\n**NOT** the signups, refer to {@link sign_up_start_date} for signup start"
 					},
 					"physical_end_date": {
 						"$ref": "#/components/schemas/FirebaseFirestore.Timestamp",
-						"description": "Event end time for the event i.e the last day members will be at the lodge,\r\nis optionial in case of one day events. **NOT** the signups, refer to\r\n{@link sign_up_end_date} for signup end date"
+						"description": "Event end time for the event i.e the last day members will be at the lodge,\nis optionial in case of one day events. **NOT** the signups, refer to\n{@link sign_up_end_date} for signup end date"
 					},
 					"max_occupancy": {
 						"type": "number",
@@ -1611,7 +1611,7 @@
 						"description": "Webhook post received"
 					}
 				},
-				"description": "Webhook endpoint for Stripe events.\r\nThis single endpoint is setup in the Stripe developer config to handle various events.",
+				"description": "Webhook endpoint for Stripe events.\nThis single endpoint is setup in the Stripe developer config to handle various events.",
 				"security": [],
 				"parameters": []
 			}
@@ -1794,7 +1794,7 @@
 						}
 					}
 				},
-				"description": "Creates a new booking session for the date ranges passed in,\r\nwill return any existing sessions if they have been started in\r\nthe last 30 minutes (the minimum period stripe has to persist a session for)",
+				"description": "Creates a new booking session for the date ranges passed in,\nwill return any existing sessions if they have been started in\nthe last 30 minutes (the minimum period stripe has to persist a session for)",
 				"security": [
 					{
 						"jwt": [
@@ -1832,7 +1832,7 @@
 						}
 					}
 				},
-				"description": "Fetches latest events starting from the event with the latest starting date\r\n(**NOT** the signup open date) based on limit. Is paginated with a cursor",
+				"description": "Fetches latest events starting from the event with the latest starting date\n(**NOT** the signup open date) based on limit. Is paginated with a cursor",
 				"security": [],
 				"parameters": [
 					{
@@ -1871,7 +1871,7 @@
 						}
 					}
 				},
-				"description": "Fetches latest events starting from the event with the latest starting date\r\n(**NOT** the signup open date) based on limit. Is paginated with a cursor.\r\n\r\nThis endpoint is only accessible to members as it includes the sign up links\r\nmembers-only events",
+				"description": "Fetches latest events starting from the event with the latest starting date\n(**NOT** the signup open date) based on limit. Is paginated with a cursor.\n\nThis endpoint is only accessible to members as it includes the sign up links\nmembers-only events",
 				"security": [
 					{
 						"jwt": [
@@ -1980,7 +1980,7 @@
 						}
 					}
 				},
-				"description": "This method fetches users based on a booking date range.\r\nThis method requires an admin JWT token.",
+				"description": "This method fetches users based on a booking date range.\nThis method requires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2216,7 +2216,7 @@
 						}
 					}
 				},
-				"description": "Get a user by their UID.\r\nRequires an admin JWT token.",
+				"description": "Get a user by their UID.\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2245,7 +2245,7 @@
 						"description": "Created"
 					}
 				},
-				"description": "Adds a new user to the database with their UID and user data.\r\nRequires an admin JWT token.",
+				"description": "Adds a new user to the database with their UID and user data.\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2276,7 +2276,7 @@
 						"description": "Edited"
 					}
 				},
-				"description": "Edits a list of users with updated user additional info.\r\nRequires an admin JWT token.",
+				"description": "Edits a list of users with updated user additional info.\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2307,7 +2307,7 @@
 						"description": "Promoted user"
 					}
 				},
-				"description": "Promotes a user to a member. This returns a conflict when the user is already a member.\r\nRequires an admin JWT token.",
+				"description": "Promotes a user to a member. This returns a conflict when the user is already a member.\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2338,7 +2338,7 @@
 						"description": "Demoted user"
 					}
 				},
-				"description": "Demotes a member to a guest. This returns a conflict when the user is already a guest.\r\nRequires an admin JWT token.",
+				"description": "Demotes a member to a guest. This returns a conflict when the user is already a guest.\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2369,7 +2369,7 @@
 						"description": "Demoted all non-admin users"
 					}
 				},
-				"description": "Demotes all non-admin users to guests. This is used to purge all membership statuses at the end of a billing cycle.\r\nRequires an admin JWT token.",
+				"description": "Demotes all non-admin users to guests. This is used to purge all membership statuses at the end of a billing cycle.\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [
@@ -2388,7 +2388,7 @@
 						"description": "Coupon Added"
 					}
 				},
-				"description": "Adds a coupon to a user's stripe id.\r\nRequires an admin JWT token.",
+				"description": "Adds a coupon to a user's stripe id.\nRequires an admin JWT token.",
 				"security": [
 					{
 						"jwt": [

--- a/server/src/middleware/__generated__/swagger.json
+++ b/server/src/middleware/__generated__/swagger.json
@@ -438,6 +438,10 @@
 						"format": "double",
 						"description": "Max number of attendees at this event, left as optional for uncapped",
 						"example": 30
+					},
+					"is_members_only": {
+						"type": "boolean",
+						"description": "If `true` then only members should see the sign up link"
 					}
 				},
 				"required": [
@@ -1402,6 +1406,10 @@
 						"format": "double",
 						"description": "Max number of attendees at this event, left as optional for uncapped",
 						"example": 30
+					},
+					"is_members_only": {
+						"type": "boolean",
+						"description": "If `true` then only members should see the sign up link"
 					}
 				},
 				"type": "object",
@@ -1826,6 +1834,51 @@
 				},
 				"description": "Fetches latest events starting from the event with the latest starting date\n(**NOT** the signup open date) based on limit. Is paginated with a cursor",
 				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"default": 20,
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "cursor",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/events/for-members": {
+			"get": {
+				"operationId": "GetAllEventsAsMember",
+				"responses": {
+					"200": {
+						"description": "Successfully fetched all events",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/GetAllEventsResponse"
+								}
+							}
+						}
+					}
+				},
+				"description": "Fetches latest events starting from the event with the latest starting date\n(**NOT** the signup open date) based on limit. Is paginated with a cursor",
+				"security": [
+					{
+						"jwt": [
+							"member"
+						]
+					}
+				],
 				"parameters": [
 					{
 						"in": "query",

--- a/server/src/service-layer/controllers/EventController.ts
+++ b/server/src/service-layer/controllers/EventController.ts
@@ -63,7 +63,10 @@ export class EventController extends Controller {
 
   /**
    * Fetches latest events starting from the event with the latest starting date
-   * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+   * (**NOT** the signup open date) based on limit. Is paginated with a cursor.
+   *
+   * This endpoint is only accessible to members as it includes the sign up links
+   * members-only events
    */
   @Get("for-members")
   @Security("jwt", ["member"])

--- a/server/src/service-layer/controllers/EventController.ts
+++ b/server/src/service-layer/controllers/EventController.ts
@@ -1,29 +1,29 @@
 import EventService from "data-layer/services/EventService"
 import { GetAllEventsResponse } from "service-layer/response-models/EventResponse"
-import { Controller, Get, Query, Route, SuccessResponse } from "tsoa"
+import { Controller, Get, Query, Route, Security, SuccessResponse } from "tsoa"
 import { ONE_MINUTE_IN_MS } from "../../business-layer/utils/EventConstants"
 import { Timestamp } from "firebase-admin/firestore"
 
 @Route("events")
 export class EventController extends Controller {
   /**
-   * Fetches latest events starting from the event with the latest starting date
-   * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+   * Fetches events with pagination based on cursor
+   * @param limit Maximum number of events to fetch
+   * @param cursor Pagination cursor
+   * @param isMember Whether the request is from a member
+   * @returns Events response with next cursor
    */
-  @Get()
-  @SuccessResponse("200", "Successfully fetched all events")
-  public async getAllEvents(
-    @Query() limit: number = 20,
-    @Query() cursor?: string
+  private async fetchEvents(
+    limit: number = 20,
+    cursor?: string,
+    isMember: boolean = false
   ): Promise<GetAllEventsResponse> {
     try {
       const eventService = new EventService()
-
       let snapshot
       if (cursor) {
         snapshot = await eventService.getEventSnapshot(cursor)
       }
-
       const res = await eventService.getAllEvents(limit, snapshot)
       const currentTime = Timestamp.now()
 
@@ -31,9 +31,11 @@ export class EventController extends Controller {
         const eventStartTime = event.sign_up_start_date
         const timeDifference =
           eventStartTime.toMillis() - currentTime.toMillis()
-
         // 1 minute (60000 milliseconds)
-        if (timeDifference > ONE_MINUTE_IN_MS) {
+        if (
+          timeDifference > ONE_MINUTE_IN_MS ||
+          (!isMember && event.is_members_only)
+        ) {
           delete event.google_forms_link
         }
       })
@@ -44,5 +46,32 @@ export class EventController extends Controller {
         error: "Something went wrong when fetching all events, please try again"
       }
     }
+  }
+
+  /**
+   * Fetches latest events starting from the event with the latest starting date
+   * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+   */
+  @Get()
+  @SuccessResponse("200", "Successfully fetched all events")
+  public async getAllEvents(
+    @Query() limit: number = 20,
+    @Query() cursor?: string
+  ): Promise<GetAllEventsResponse> {
+    return this.fetchEvents(limit, cursor, false)
+  }
+
+  /**
+   * Fetches latest events starting from the event with the latest starting date
+   * (**NOT** the signup open date) based on limit. Is paginated with a cursor
+   */
+  @Get("for-members")
+  @Security("jwt", ["member"])
+  @SuccessResponse("200", "Successfully fetched all events")
+  public async getAllEventsAsMember(
+    @Query() limit: number = 20,
+    @Query() cursor?: string
+  ): Promise<GetAllEventsResponse> {
+    return this.fetchEvents(limit, cursor, true)
   }
 }


### PR DESCRIPTION
## Overview

Some events should not show the google form link if it is restricted to members. This PR allows admin the option to hide the link and only allow fetching if admin



![image](https://github.com/user-attachments/assets/3d372de9-17f3-4ae2-9db6-81e9457cf33c)

**Unauthed**
![image](https://github.com/user-attachments/assets/3f34eafb-0723-4bbd-94b7-bb2affccc68a)
**Authed**
![image](https://github.com/user-attachments/assets/b1b8c479-5b90-47f8-a721-da3b3dc0fcb0)

**Admin Option**
![image](https://github.com/user-attachments/assets/c5fe9dc8-4213-4ac9-8de4-ce8fe7ff5534)
