### PR TITLE
Add shop layout and components for displaying merchandise

### DIFF
--- a/client/sanity.config.ts
+++ b/client/sanity.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
               ),
 
             // Regular document types
+            S.documentTypeListItem("shop-item").title("Shop Item"),
             S.documentTypeListItem("about-item").title("About Item"),
             S.documentTypeListItem("contact-detail").title("Contact Detail"),
             S.documentTypeListItem("life-member").title("Life Member"),

--- a/client/sanity/schema.ts
+++ b/client/sanity/schema.ts
@@ -6,6 +6,7 @@ import { type SchemaTypeDefinition } from "sanity"
 import { CommitteeMemberSchema } from "@/models/sanity/CommitteeMembers/Schema"
 import { LifeMemberSchema } from "@/models/sanity/LifeMembers/Schema"
 import { PoliciesSchema } from "@/models/sanity/Policies/Schema"
+import { ShopItemSchema } from "@/models/sanity/ShopItem/Schema"
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
@@ -15,6 +16,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     LodgeInfoSchema,
     PoliciesSchema,
     CommitteeMemberSchema,
-    LifeMemberSchema
+    LifeMemberSchema,
+    ShopItemSchema
   ]
 }

--- a/client/src/app/shop/layout.tsx
+++ b/client/src/app/shop/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next"
+import { ReactNode } from "react"
+import FullPageBackgroundImage from "@/components/generic/FullPageBackgroundImage/FullPageBackgroundImage"
+
+export const metadata: Metadata = {
+  title: "UASC Merch",
+  description: "Browse our collection UASC merch!"
+}
+
+export default function ShopLayout({ children }: { children: ReactNode }) {
+  return <FullPageBackgroundImage>{children}</FullPageBackgroundImage>
+}

--- a/client/src/app/shop/page.tsx
+++ b/client/src/app/shop/page.tsx
@@ -1,0 +1,38 @@
+import { SanityImageUrl, sanityQuery } from "../../../sanity/lib/utils"
+import { SHOP_ITEMS_GROQ_QUERY, ShopItem } from "@/models/sanity/ShopItem/Utils"
+import ShopView from "@/components/composite/ShopView/ShopView"
+
+const Shop = async () => {
+  let shopItems: ShopItem[] = []
+  let error: Error | null = null
+
+  try {
+    shopItems = await sanityQuery<ShopItem[]>(SHOP_ITEMS_GROQ_QUERY)
+
+    // Process images with SanityImageUrl
+    shopItems = shopItems.map((item) => ({
+      ...item,
+      mainImageUrl: new SanityImageUrl(item.mainImageUrl)
+        .width(300)
+        .autoFormat()
+        .toString(),
+      secondaryImageUrl: item.secondaryImageUrl
+        ? new SanityImageUrl(item.secondaryImageUrl)
+            .width(300)
+            .autoFormat()
+            .toString()
+        : undefined
+    }))
+  } catch (e) {
+    console.error("Error fetching shop items:", e)
+    error = e instanceof Error ? e : new Error("Unknown error occurred")
+  }
+
+  return (
+    <main className="min-h-screen py-8">
+      <ShopView items={shopItems} error={error} />
+    </main>
+  )
+}
+
+export default Shop

--- a/client/src/components/composite/Navbar/Navbar.tsx
+++ b/client/src/components/composite/Navbar/Navbar.tsx
@@ -72,13 +72,21 @@ const Navbar = ({
       <div className="flex w-full">
         <Logo />
         <div
-          className={`left-0 md:ml-auto ${isOpen ? "flex" : "hidden"} bg-gray-1 absolute top-12 h-fit min-h-screen
-          w-full flex-col items-center justify-start gap-2 self-end pt-8 md:relative md:top-0 md:ml-auto
-          md:flex md:min-h-full md:flex-row md:items-end md:justify-end md:gap-8 md:bg-none md:pr-4 md:pt-0`}
+          className={`
+            absolute left-0 top-12 h-fit min-h-screen w-full
+            flex-col items-center justify-start gap-2 self-end pt-8
+            ${isOpen ? "flex" : "hidden"}
+            bg-gray-1
+            
+            md:relative md:top-0 md:ml-auto md:flex
+            md:min-h-full md:flex-row md:items-end md:justify-end
+            md:gap-7 md:bg-none md:pr-4 md:pt-0
+          `}
         >
           <WrappedTab to="/">Home</WrappedTab>
           <WrappedTab to="/bookings">Book the Lodge!</WrappedTab>
           <WrappedTab to="/events">Events</WrappedTab>
+          <WrappedTab to="/shop">Shop</WrappedTab>
           <span className="hidden md:block">
             <WrappedMenuTab displayName="about" to="/about">
               <AboutMenuItemsFull />

--- a/client/src/components/composite/ShopView/ShopView.story.tsx
+++ b/client/src/components/composite/ShopView/ShopView.story.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import ShopView from "./ShopView"
+import { ShopItem as ShopItemType } from "../../../models/sanity/ShopItem/Utils"
+
+const meta: Meta<typeof ShopView> = {
+  title: "Composite/ShopView",
+  component: ShopView,
+  parameters: {
+    layout: "fullscreen"
+  },
+  tags: ["autodocs"]
+}
+
+export default meta
+type Story = StoryObj<typeof ShopView>
+
+// Sample shop items for stories
+const mockItems: ShopItemType[] = [
+  {
+    _id: "1",
+    itemName: "Winter Ski Jacket",
+    mainImageUrl: "https://placehold.co/400x300?text=Ski+Jacket",
+    secondaryImageUrl: "https://placehold.co/400x300?text=Ski+Jacket+Back",
+    googleFormLink: "https://forms.google.com/product1",
+    displayPrice: "$149.99",
+    description:
+      "High-quality waterproof ski jacket perfect for cold weather conditions."
+  },
+  {
+    _id: "2",
+    itemName: "Ski Goggles",
+    mainImageUrl: "https://placehold.co/400x300?text=Ski+Goggles",
+    secondaryImageUrl: "https://placehold.co/400x300?text=Goggles+Side",
+    googleFormLink: "https://forms.google.com/product2",
+    displayPrice: "$79.99",
+    description:
+      "Anti-fog ski goggles with UV protection and wide field of view."
+  },
+  {
+    _id: "3",
+    itemName: "Thermal Base Layer",
+    mainImageUrl: "https://placehold.co/400x300?text=Base+Layer",
+    secondaryImageUrl: "https://placehold.co/400x300?text=Base+Layer+Detail",
+    googleFormLink: "https://forms.google.com/product3",
+    displayPrice: "$49.99",
+    description:
+      "Moisture-wicking thermal base layer to keep you warm and dry on the slopes."
+  },
+  {
+    _id: "4",
+    itemName: "Ski Poles",
+    mainImageUrl: "https://placehold.co/400x300?text=Ski+Poles",
+    secondaryImageUrl: "https://placehold.co/400x300?text=Ski+Poles+Detail",
+    googleFormLink: "https://forms.google.com/product4",
+    displayPrice: "$59.99",
+    description:
+      "Durable aluminum ski poles with ergonomic handles for all-day comfort."
+  }
+]
+
+export const Default: Story = {
+  args: {
+    items: mockItems
+  }
+}
+
+export const Empty: Story = {
+  args: {
+    items: []
+  }
+}
+
+export const SingleItem: Story = {
+  args: {
+    items: [mockItems[0]]
+  }
+}
+
+export const LoadingState: Story = {
+  args: {
+    isLoading: true
+  }
+}
+
+export const ErrorState: Story = {
+  args: {
+    error: new Error("Failed to fetch shop items")
+  }
+}
+
+export const EmptyState: Story = {
+  args: {
+    items: []
+  }
+}

--- a/client/src/components/composite/ShopView/ShopView.tsx
+++ b/client/src/components/composite/ShopView/ShopView.tsx
@@ -3,6 +3,9 @@ import { ShopItem as ShopItemType } from "../../../models/sanity/ShopItem/Utils"
 import ShopItem from "@/components/generic/Shop/ShopItem"
 
 interface ShopViewProps {
+  /**
+   * Array of {@link ShopItem} to display
+   */
   items?: ShopItemType[]
   isLoading?: boolean
   error?: Error | null

--- a/client/src/components/composite/ShopView/ShopView.tsx
+++ b/client/src/components/composite/ShopView/ShopView.tsx
@@ -1,0 +1,82 @@
+import React from "react"
+import { ShopItem as ShopItemType } from "../../../models/sanity/ShopItem/Utils"
+import ShopItem from "@/components/generic/Shop/ShopItem"
+
+interface ShopViewProps {
+  items?: ShopItemType[]
+  isLoading?: boolean
+  error?: Error | null
+}
+
+/**
+ * ShopView component displays a responsive grid of shop items
+ * with optimized layout for different item counts
+ *
+ * @component
+ * @param items - Array of shop items to display
+ * @param isLoading - Boolean indicating if items are loading
+ * @param error - Error object if fetching failed
+ */
+const ShopView: React.FC<ShopViewProps> = ({
+  items,
+  isLoading = false,
+  error = null
+}) => {
+  if (isLoading) {
+    return (
+      <div className="flex h-64 w-full items-center justify-center">
+        <div className="border-light-blue-60 border-t-light-blue-100 h-12 w-12 animate-spin rounded-full border-4" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-64 w-full items-center justify-center">
+        <p className="text-h4 text-red">
+          Failed to load shop items. Please try again later.
+        </p>
+      </div>
+    )
+  }
+
+  const getGridClassName = (itemCount: number) => {
+    switch (itemCount) {
+      case 0:
+        return ""
+      case 1:
+        return "grid-cols-1 max-w-md mx-auto"
+      case 2:
+        return "grid-cols-1 sm:grid-cols-2 max-w-2xl mx-auto"
+      case 3:
+        return "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 max-w-4xl mx-auto"
+      default:
+        return "grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+    }
+  }
+  const itemCount = items?.length || 0
+
+  return (
+    <section className="container mx-auto max-w-[1200px] px-4 py-8 md:px-6 lg:px-8">
+      <h2 className="text-h2 text-dark-blue-100 mb-8 text-center">
+        Shop Our Products
+      </h2>
+
+      {items && items.length > 0 ? (
+        <div className={`grid gap-6 ${getGridClassName(itemCount)}`}>
+          {items.map((item) => (
+            <div key={item._id} className="flex">
+              <ShopItem item={item} />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-h4 text-gray-4 text-center">
+          No products available at the moment.
+        </p>
+      )}
+    </section>
+  )
+}
+
+export default ShopView

--- a/client/src/components/generic/Shop/ProductImage/ProductImage.story.tsx
+++ b/client/src/components/generic/Shop/ProductImage/ProductImage.story.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import ProductImage from "./ProductImage"
+import { useState } from "react"
+
+const meta: Meta<typeof ProductImage> = {
+  component: ProductImage,
+  title: "Shop/ProductImage",
+  tags: ["autodocs"],
+  argTypes: {
+    mainImageUrl: {
+      control: "text",
+      description: "URL for the main product image"
+    },
+    secondaryImageUrl: {
+      control: "text",
+      description: "Optional URL for the secondary product image"
+    },
+    itemName: {
+      control: "text",
+      description: "Product name for accessibility"
+    },
+    showSecondaryImage: {
+      control: "boolean",
+      description: "Whether to show the secondary image"
+    },
+    setShowSecondaryImage: {
+      action: "setShowSecondaryImage",
+      description: "Function to toggle image visibility state"
+    }
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    )
+  ]
+}
+
+export default meta
+
+type Story = StoryObj<typeof ProductImage>
+
+export const Default: Story = {
+  args: {
+    mainImageUrl: "https://source.unsplash.com/random/300x200?product",
+    itemName: "Sample Product",
+    showSecondaryImage: false,
+    setShowSecondaryImage: () => {}
+  }
+}
+
+export const WithSecondaryImage: Story = {
+  args: {
+    mainImageUrl: "https://source.unsplash.com/random/300x200?product1",
+    secondaryImageUrl: "https://source.unsplash.com/random/300x200?product2",
+    itemName: "Product with Multiple Views",
+    showSecondaryImage: false,
+    setShowSecondaryImage: () => {}
+  }
+}
+
+export const Interactive: Story = {
+  render: () => {
+    const [showSecondary, setShowSecondary] = useState(false)
+
+    return (
+      <ProductImage
+        mainImageUrl="https://source.unsplash.com/random/300x200?product3"
+        secondaryImageUrl="https://source.unsplash.com/random/300x200?product4"
+        itemName="Interactive Product"
+        showSecondaryImage={showSecondary}
+        setShowSecondaryImage={setShowSecondary}
+      />
+    )
+  }
+}

--- a/client/src/components/generic/Shop/ProductImage/ProductImage.story.tsx
+++ b/client/src/components/generic/Shop/ProductImage/ProductImage.story.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import ProductImage from "./ProductImage"
-import { useState } from "react"
 
 const meta: Meta<typeof ProductImage> = {
   component: ProductImage,
@@ -62,15 +61,13 @@ export const WithSecondaryImage: Story = {
 
 export const Interactive: Story = {
   render: () => {
-    const [showSecondary, setShowSecondary] = useState(false)
-
     return (
       <ProductImage
         mainImageUrl="https://source.unsplash.com/random/300x200?product3"
         secondaryImageUrl="https://source.unsplash.com/random/300x200?product4"
         itemName="Interactive Product"
-        showSecondaryImage={showSecondary}
-        setShowSecondaryImage={setShowSecondary}
+        showSecondaryImage={false}
+        setShowSecondaryImage={() => {}}
       />
     )
   }

--- a/client/src/components/generic/Shop/ProductImage/ProductImage.tsx
+++ b/client/src/components/generic/Shop/ProductImage/ProductImage.tsx
@@ -1,0 +1,75 @@
+import React from "react"
+import Image from "next/image"
+
+/**
+ * A component that displays product images with the ability to toggle between main and secondary images.
+ * @param props - Component props
+ * @param props.mainImageUrl - URL of the main product image
+ * @param [props.secondaryImageUrl] - Optional URL of the secondary product image
+ * @param props.itemName - Name of the product (used for alt text)
+ * @param props.showSecondaryImage - Flag indicating whether to show the secondary image
+ * @param props.setShowSecondaryImage - Function to toggle secondary image visibility
+ * @example
+ * <ProductImage
+ *   mainImageUrl="https://example.com/product-main.jpg"
+ *   secondaryImageUrl="https://example.com/product-secondary.jpg"
+ *   itemName="Blue T-Shirt"
+ *   showSecondaryImage={false}
+ *   setShowSecondaryImage={(show) => setShowImage(show)}
+ * />
+ */
+const ProductImage: React.FC<{
+  mainImageUrl: string
+  secondaryImageUrl?: string
+  itemName: string
+  showSecondaryImage: boolean
+  setShowSecondaryImage: (show: boolean) => void
+}> = ({
+  mainImageUrl,
+  secondaryImageUrl,
+  itemName,
+  showSecondaryImage,
+  setShowSecondaryImage
+}) => {
+  const toggleImage = () => {
+    if (secondaryImageUrl) {
+      setShowSecondaryImage(!showSecondaryImage)
+    }
+  }
+
+  return (
+    <div className="relative h-64 w-full overflow-hidden">
+      <div className="relative h-full w-full">
+        <Image
+          src={
+            showSecondaryImage && secondaryImageUrl
+              ? secondaryImageUrl
+              : mainImageUrl
+          }
+          alt={itemName}
+          className="h-full w-full object-cover transition-opacity duration-300"
+          onClick={toggleImage}
+          fill
+        />
+      </div>
+
+      {/* Image navigation dots shown only if secondary image exists */}
+      {secondaryImageUrl && (
+        <div className="absolute bottom-2 left-1/2 flex -translate-x-1/2 transform space-x-2">
+          <button
+            className={`h-2 w-2 rounded-full ${!showSecondaryImage ? "bg-dark-blue-100" : "bg-gray-3"}`}
+            onClick={() => setShowSecondaryImage(false)}
+            aria-label="View main image"
+          />
+          <button
+            className={`h-2 w-2 rounded-full ${showSecondaryImage ? "bg-dark-blue-100" : "bg-gray-3"}`}
+            onClick={() => setShowSecondaryImage(true)}
+            aria-label="View secondary image"
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ProductImage

--- a/client/src/components/generic/Shop/ProductInfo/ProductInfo.story.tsx
+++ b/client/src/components/generic/Shop/ProductInfo/ProductInfo.story.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import ProductInfo from "./ProductInfo"
+
+const meta: Meta<typeof ProductInfo> = {
+  component: ProductInfo,
+  title: "Shop/ProductInfo",
+  tags: ["autodocs"],
+  argTypes: {
+    itemName: {
+      control: "text",
+      description: "Name of the product"
+    },
+    displayPrice: {
+      control: "text",
+      description: "Optional price to display"
+    },
+    description: {
+      control: "text",
+      description: "Optional product description"
+    },
+    googleFormLink: {
+      control: "text",
+      description: "Link to Google Form for ordering"
+    }
+  },
+  parameters: {
+    layout: "centered"
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm rounded-lg bg-white p-2">
+        <Story />
+      </div>
+    )
+  ]
+}
+
+export default meta
+
+type Story = StoryObj<typeof ProductInfo>
+
+export const Default: Story = {
+  args: {
+    itemName: "Classic T-Shirt",
+    displayPrice: "$24.99",
+    description: "A comfortable cotton t-shirt perfect for everyday wear.",
+    googleFormLink: "https://forms.google.com/sample-form"
+  }
+}
+
+export const WithoutPrice: Story = {
+  args: {
+    itemName: "Limited Edition Item",
+    description: "Exclusive item with custom pricing based on options.",
+    googleFormLink: "https://forms.google.com/custom-pricing-form"
+  }
+}
+
+export const WithoutDescription: Story = {
+  args: {
+    itemName: "Simple Product",
+    displayPrice: "$19.99",
+    googleFormLink: "https://forms.google.com/simple-product-form"
+  }
+}
+
+export const LongDescription: Story = {
+  args: {
+    itemName: "Premium Product",
+    displayPrice: "$59.99",
+    description:
+      "This premium product features high-quality materials and craftsmanship. Made with attention to detail, this item is built to last and provides exceptional value. Perfect for those who appreciate quality and durability in their purchases.",
+    googleFormLink: "https://forms.google.com/premium-product-form"
+  }
+}

--- a/client/src/components/generic/Shop/ProductInfo/ProductInfo.tsx
+++ b/client/src/components/generic/Shop/ProductInfo/ProductInfo.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+
+const ProductInfo: React.FC<{
+  itemName: string
+  displayPrice?: string
+  description?: string
+  googleFormLink: string
+}> = ({ itemName, displayPrice, description, googleFormLink }) => {
+  return (
+    <div className="flex flex-1 flex-col gap-2 p-4">
+      <div className="flex flex-col">
+        <h3 className="text-h3 text-black">{itemName}</h3>
+        {displayPrice && (
+          <p className="text-h4 text-dark-blue-100 font-bold">{displayPrice}</p>
+        )}
+      </div>
+      {description && (
+        <p className="text-p text-gray-4 line-clamp-3">{description}</p>
+      )}
+
+      <a
+        href={googleFormLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="bg-orange hover:bg-orange-60 mt-4 rounded-md px-4 py-2 text-center font-medium text-white transition-colors duration-300"
+      >
+        Order Now
+      </a>
+    </div>
+  )
+}
+
+export default ProductInfo

--- a/client/src/components/generic/Shop/ShopItem.story.tsx
+++ b/client/src/components/generic/Shop/ShopItem.story.tsx
@@ -1,0 +1,107 @@
+import React from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+import ShopItem from "./ShopItem"
+import { ShopItem as ShopItemType } from "../../../models/sanity/ShopItem/Utils"
+
+const meta: Meta<typeof ShopItem> = {
+  component: ShopItem,
+  title: "Components/Shop/ShopItem",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered"
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Sample shop items for different variations
+const basicItem: ShopItemType = {
+  _id: "1",
+  itemName: "Basic T-Shirt",
+  mainImageUrl:
+    "https://via.placeholder.com/400x300/f8f8f8/333333?text=Main+Image",
+  googleFormLink: "https://forms.google.com/example",
+  displayPrice: "$25.00"
+}
+
+const fullItem: ShopItemType = {
+  _id: "2",
+  itemName: "Premium Sweatshirt",
+  mainImageUrl:
+    "https://via.placeholder.com/400x300/e9f5ff/333333?text=Main+Image",
+  secondaryImageUrl:
+    "https://via.placeholder.com/400x300/ffe9e9/333333?text=Secondary+Image",
+  googleFormLink: "https://forms.google.com/example",
+  displayPrice: "$45.00",
+  description:
+    "High-quality sweatshirt made from organic cotton. Features a comfortable fit with minimal shrinkage after washing."
+}
+
+const longDescriptionItem: ShopItemType = {
+  _id: "3",
+  itemName: "Limited Edition Hoodie",
+  mainImageUrl:
+    "https://via.placeholder.com/400x300/f0f0f0/333333?text=Main+Image",
+  secondaryImageUrl:
+    "https://via.placeholder.com/400x300/f8f8f8/333333?text=Secondary+Image",
+  googleFormLink: "https://forms.google.com/example",
+  displayPrice: "$65.00",
+  description:
+    "This limited edition hoodie is crafted from premium materials for ultimate comfort and style. Features include double-lined hood, reinforced seams, and a kangaroo pocket. Each piece is uniquely numbered and comes with a certificate of authenticity."
+}
+
+const expensiveItem: ShopItemType = {
+  _id: "4",
+  itemName: "Designer Jacket",
+  mainImageUrl:
+    "https://via.placeholder.com/400x300/fff8e8/333333?text=Main+Image",
+  googleFormLink: "https://forms.google.com/example",
+  displayPrice: "$199.99",
+  description: "Premium designer jacket with water-resistant exterior."
+}
+
+export const Basic: Story = {
+  args: {
+    item: basicItem
+  }
+}
+
+export const WithSecondaryImage: Story = {
+  args: {
+    item: fullItem
+  }
+}
+
+export const WithLongDescription: Story = {
+  args: {
+    item: longDescriptionItem
+  }
+}
+
+export const HighPriceItem: Story = {
+  args: {
+    item: expensiveItem
+  }
+}
+
+export const MultipleItems: Story = {
+  decorators: [
+    () => (
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <ShopItem item={basicItem} />
+        <ShopItem item={fullItem} />
+        <ShopItem item={expensiveItem} />
+      </div>
+    )
+  ],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "Displays multiple shop items in a grid layout to demonstrate how they appear in a collection."
+      }
+    }
+  }
+}

--- a/client/src/components/generic/Shop/ShopItem.tsx
+++ b/client/src/components/generic/Shop/ShopItem.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import React, { useState } from "react"
+import { ShopItem as ShopItemType } from "../../../models/sanity/ShopItem/Utils"
+import ProductImage from "@/components/generic/Shop/ProductImage/ProductImage"
+import ProductInfo from "@/components/generic/Shop/ProductInfo/ProductInfo"
+
+interface ShopItemProps {
+  item: ShopItemType
+}
+
+/**
+ * ShopItem component displays a product card with image and information
+ *
+ * @component
+ * @param item - The shop item data containing product details
+ *
+ * @example
+ * // Example usage:
+ * <ShopItem
+ *   item={{
+ *     itemName: "Product Title",
+ *     mainImageUrl: "/images/product.jpg",
+ *     secondaryImageUrl: "/images/product-alt.jpg",
+ *     googleFormLink: "https://forms.google.com/product-order",
+ *     displayPrice: "$19.99",
+ *     description: "Product description goes here"
+ *   }}
+ * />
+ */
+const ShopItem: React.FC<ShopItemProps> = ({
+  item: {
+    itemName,
+    mainImageUrl,
+    secondaryImageUrl,
+    googleFormLink,
+    displayPrice,
+    description
+  }
+}) => {
+  // State to toggle between primary and secondary product images
+  const [showSecondaryImage, setShowSecondaryImage] = useState(false)
+
+  return (
+    <div className="flex h-full max-w-xs min-w-full flex-col overflow-hidden rounded-lg bg-white shadow-md transition-shadow duration-300 hover:shadow-xl">
+      <ProductImage
+        mainImageUrl={mainImageUrl}
+        secondaryImageUrl={secondaryImageUrl}
+        itemName={itemName}
+        showSecondaryImage={showSecondaryImage}
+        setShowSecondaryImage={setShowSecondaryImage}
+      />
+
+      <ProductInfo
+        itemName={itemName}
+        displayPrice={displayPrice}
+        description={description}
+        googleFormLink={googleFormLink}
+      />
+    </div>
+  )
+}
+
+export default ShopItem

--- a/client/src/components/generic/Shop/ShopItem.tsx
+++ b/client/src/components/generic/Shop/ShopItem.tsx
@@ -42,7 +42,7 @@ const ShopItem: React.FC<ShopItemProps> = ({
   const [showSecondaryImage, setShowSecondaryImage] = useState(false)
 
   return (
-    <div className="flex h-full max-w-xs min-w-full flex-col overflow-hidden rounded-lg bg-white shadow-md transition-shadow duration-300 hover:shadow-xl">
+    <div className="flex h-full min-w-full max-w-xs flex-col overflow-hidden rounded-lg bg-white shadow-md transition-shadow duration-300 hover:shadow-xl">
       <ProductImage
         mainImageUrl={mainImageUrl}
         secondaryImageUrl={secondaryImageUrl}

--- a/client/src/models/sanity/ShopItem/Schema.ts
+++ b/client/src/models/sanity/ShopItem/Schema.ts
@@ -37,7 +37,18 @@ export const ShopItemSchema: SchemaTypeDefinition = {
       title: "Display Price",
       type: "string",
       description: "Example: '$19.99'",
-      validation: (Rule) => Rule.required()
+      validation: (Rule) =>
+        Rule.required().custom((price) => {
+          if (typeof price === "undefined") {
+            return true // Allow undefined values
+          }
+
+          // Regex for price formats like $19.99, $19, £10.50, etc.
+          const regex = /^\$\s?(\d+|\d{1,3}(,\d{3})*)(\.\d{1,2})?$/
+          return regex.test(price)
+            ? true
+            : "Please enter a valid price format (e.g. $19.99)"
+        })
     }),
     defineField({
       name: "description",

--- a/client/src/models/sanity/ShopItem/Schema.ts
+++ b/client/src/models/sanity/ShopItem/Schema.ts
@@ -54,7 +54,11 @@ export const ShopItemSchema: SchemaTypeDefinition = {
       name: "description",
       title: "Description",
       type: "text",
-      description: "A brief description of the item."
+      description: "A brief description of the item.",
+      validation: (Rule) =>
+        Rule.max(250).warning(
+          "Description should be concise for better display"
+        )
     })
   ]
 }

--- a/client/src/models/sanity/ShopItem/Schema.ts
+++ b/client/src/models/sanity/ShopItem/Schema.ts
@@ -1,0 +1,49 @@
+import { defineField, SchemaTypeDefinition } from "sanity"
+
+export const ShopItemSchema: SchemaTypeDefinition = {
+  name: "shop-item",
+  title: "Shop Item",
+  type: "document",
+  fields: [
+    defineField({
+      name: "itemName",
+      title: "Item Name",
+      type: "string",
+      description: "Example: 'Red Lodge T-Shirt'",
+      validation: (Rule) => Rule.required()
+    }),
+    defineField({
+      name: "mainImage",
+      title: "Main Image",
+      type: "image",
+      description: "This is the primary image for the item.",
+      validation: (Rule) => Rule.required()
+    }),
+    defineField({
+      name: "secondaryImage",
+      title: "Secondary Image",
+      description: "This is an optional secondary image for the item.",
+      type: "image"
+    }),
+    defineField({
+      name: "googleFormLink",
+      title: "Google Form Link",
+      type: "url",
+      description: "Link to the Google Form for purchasing this item.",
+      validation: (Rule) => Rule.required()
+    }),
+    defineField({
+      name: "displayPrice",
+      title: "Display Price",
+      type: "string",
+      description: "Example: '$19.99'",
+      validation: (Rule) => Rule.required()
+    }),
+    defineField({
+      name: "description",
+      title: "Description",
+      type: "text",
+      description: "A brief description of the item."
+    })
+  ]
+}

--- a/client/src/models/sanity/ShopItem/Utils.ts
+++ b/client/src/models/sanity/ShopItem/Utils.ts
@@ -1,0 +1,15 @@
+/**
+ * All store items query
+ */
+export const SHOP_ITEMS_GROQ_QUERY =
+  `*[_type == "shop-item"]{"mainImageUrl": mainImage.asset->url, "secondaryImageUrl": secondaryImage.asset->url, ...}` as const
+
+export type ShopItem = {
+  _id: string
+  itemName: string
+  mainImageUrl: string
+  secondaryImageUrl?: string
+  googleFormLink: string
+  displayPrice: string
+  description?: string
+}


### PR DESCRIPTION
# Add Sanity-connected shop functionality to UASC website

## Changes
- Created a new Sanity schema for shop items to enable e-commerce functionality
- Implemented ShopItemSchema with fields for product details including:
  - Item name
  - Main and secondary images
  - Google Form link for purchases
  - Display price
  - Item description

## Context
The UASC website already has a shop page accessible from the navigation bar but lacked the backend infrastructure to manage product listings. This PR introduces the content model in Sanity CMS needed to support the online shop, where products will be purchased through Google Forms rather than a traditional checkout system.

## Testing
- [X] Verify the shop item schema is correctly registered in Sanity Studio
- [X] Confirm content editors can create and manage shop items
- [X] Test that all fields save and render correctly in the Sanity Studio interface

### Sanity

![image](https://github.com/user-attachments/assets/0e9b188d-66a3-4e2f-a052-4e497b328d6d)

### Shop Page

![image](https://github.com/user-attachments/assets/79cdfabd-8ecb-4654-9194-43b4f895f0fb)

## Related Issues
Closes #853