### PR TITLE
Update Google Sheet secret variable names in deployment configurations

### DIFF
--- a/.github/workflows/deploy-server.production.yml
+++ b/.github/workflows/deploy-server.production.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl secrets set --config fly.production.toml "GOOGLE_SERVICE_ACCOUNT_JSON=$(echo ${{ secrets.PROD_SERVER_SERVICE_ACCOUNT }} | base64 --decode)" STRIPE_WEBHOOK_SECRET=${{ secrets.PROD_SERVER_STRIPE_WEBHOOK_SECRET }} STRIPE_API_KEY=${{ secrets.PROD_SERVER_STRIPE_API_KEY }} FRONTEND_URL=${{ secrets.PROD_FRONTEND_URL }} NODE_MAILER_EMAIL=${{ secrets.PROD_EMAIL }} NODE_MAILER_PASSWORD=${{ secrets.PROD_EMAIL_PASSWORD }} REDIRECT_MEMBERS_GOOGLE_SHEET=${{ secrets.MEMBERS_GOOGLE_SHEET_URL }}
+      - run: flyctl secrets set --config fly.production.toml "GOOGLE_SERVICE_ACCOUNT_JSON=$(echo ${{ secrets.PROD_SERVER_SERVICE_ACCOUNT }} | base64 --decode)" STRIPE_WEBHOOK_SECRET=${{ secrets.PROD_SERVER_STRIPE_WEBHOOK_SECRET }} STRIPE_API_KEY=${{ secrets.PROD_SERVER_STRIPE_API_KEY }} FRONTEND_URL=${{ secrets.PROD_FRONTEND_URL }} NODE_MAILER_EMAIL=${{ secrets.PROD_EMAIL }} NODE_MAILER_PASSWORD=${{ secrets.PROD_EMAIL_PASSWORD }} REDIRECT_MEMBERS_GOOGLE_SHEET_LINK=${{ secrets.MEMBERS_GOOGLE_SHEET_URL }}
       - run: flyctl secrets deploy --config fly.production.toml
       - run: flyctl deploy --remote-only --config fly.production.toml

--- a/.github/workflows/deploy-server.staging.yml
+++ b/.github/workflows/deploy-server.staging.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl secrets set --config fly.staging.toml "GOOGLE_SERVICE_ACCOUNT_JSON=$(echo ${{ secrets.STAGING_SERVER_SERVICE_ACCOUNT }} | base64 --decode)" STRIPE_WEBHOOK_SECRET=${{ secrets.STAGING_SERVER_STRIPE_WEBHOOK_SECRET }} STRIPE_API_KEY=${{ secrets.STAGING_SERVER_STRIPE_API_KEY }} FRONTEND_URL=${{ secrets.STAGING_FRONTEND_URL }} NODE_MAILER_EMAIL=${{ secrets.STAGING_EMAIL }} NODE_MAILER_PASSWORD=${{ secrets.STAGING_EMAIL_PASSWORD }} REDIRECT_MEMBERS_GOOGLE_SHEET="https://google.com"
+      - run: flyctl secrets set --config fly.staging.toml "GOOGLE_SERVICE_ACCOUNT_JSON=$(echo ${{ secrets.STAGING_SERVER_SERVICE_ACCOUNT }} | base64 --decode)" STRIPE_WEBHOOK_SECRET=${{ secrets.STAGING_SERVER_STRIPE_WEBHOOK_SECRET }} STRIPE_API_KEY=${{ secrets.STAGING_SERVER_STRIPE_API_KEY }} FRONTEND_URL=${{ secrets.STAGING_FRONTEND_URL }} NODE_MAILER_EMAIL=${{ secrets.STAGING_EMAIL }} NODE_MAILER_PASSWORD=${{ secrets.STAGING_EMAIL_PASSWORD }} REDIRECT_MEMBERS_GOOGLE_SHEET_LINK="https://google.com"
       - run: flyctl secrets deploy --config fly.staging.toml
       - run: flyctl deploy --remote-only --config fly.staging.toml


### PR DESCRIPTION
Renamed from `REDIRECT_MEMBERS_GOOGLE_SHEET` to `REDIRECT_MEMBERS_GOOGLE_SHEET_LINK`

in accordance with `server/src/business-layer/utils/RedirectKeys.ts`