### PR TITLE
ci: add restore keys for pnpm cache

### DIFF
--- a/.github/ci-actions/build-client/action.yml
+++ b/.github/ci-actions/build-client/action.yml
@@ -58,6 +58,9 @@ runs:
           client/node_modules
           node_modules
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          node-modules-pnpm
 
     - name: Check client builds
       env:

--- a/.github/ci-actions/build-server/action.yml
+++ b/.github/ci-actions/build-server/action.yml
@@ -23,6 +23,9 @@ runs:
           client/node_modules
           node_modules
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          node-modules-pnpm
 
     - name: Check server builds
       run: |

--- a/.github/ci-actions/codegen/action.yml
+++ b/.github/ci-actions/codegen/action.yml
@@ -23,6 +23,9 @@ runs:
           client/node_modules
           node_modules
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          node-modules-pnpm
 
     - name: Generate server code
       run: pnpm generate:types --filter server

--- a/.github/ci-actions/firebase-preview/action.yml
+++ b/.github/ci-actions/firebase-preview/action.yml
@@ -74,6 +74,9 @@ runs:
           client/node_modules
           node_modules
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          node-modules-pnpm
 
     - run: pnpm build --filter client
       env:

--- a/.github/ci-actions/lint/action.yml
+++ b/.github/ci-actions/lint/action.yml
@@ -23,6 +23,9 @@ runs:
           client/node_modules
           node_modules
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          node-modules-pnpm
 
     - name: Run ESLint on ALL files
       run: pnpm lint:all

--- a/.github/ci-actions/prettier/action.yml
+++ b/.github/ci-actions/prettier/action.yml
@@ -23,6 +23,9 @@ runs:
           client/node_modules
           node_modules
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          node-modules-pnpm
 
     - name: Run Prettier
       run: pnpm prettier:ci

--- a/.github/ci-actions/setup/action.yml
+++ b/.github/ci-actions/setup/action.yml
@@ -39,7 +39,7 @@ runs:
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
           node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          node-modules-pnpm
+          node-modules-pnpm-
 
     - name: Install dependencies
       shell: bash

--- a/.github/ci-actions/setup/action.yml
+++ b/.github/ci-actions/setup/action.yml
@@ -38,7 +38,8 @@ runs:
           node_modules
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          node-modules-pnpm-
+          node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          node-modules-pnpm
 
     - name: Install dependencies
       shell: bash

--- a/.github/ci-actions/test/action.yml
+++ b/.github/ci-actions/test/action.yml
@@ -28,6 +28,9 @@ runs:
           client/node_modules
           node_modules
         key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          node-modules-pnpm
 
     - name: Run all tests
       env:

--- a/.github/workflows/deploy-client-production.yml
+++ b/.github/workflows/deploy-client-production.yml
@@ -62,7 +62,8 @@ jobs:
             node_modules
           key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - run: pnpm build --filter client
+      - name: Build client
+        run: pnpm build --filter client
 
       - name: Publish to cloudflare
         uses: cloudflare/pages-action@v1

--- a/.github/workflows/deploy-client-staging.yml
+++ b/.github/workflows/deploy-client-staging.yml
@@ -59,7 +59,8 @@ jobs:
             node_modules
           key: node-modules-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - run: pnpm build --filter client
+      - name: Build client
+        run: pnpm build --filter client
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Adds restore keys to all actions so that upon cache miss, it'll follow the cache restore keys in order. 

This was implemented because the recent CI run failed in `master` because somehow the cache keys weren't found, hence restore keys can be used (the cache keys are looked up by date). 

Fixes # (issue)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I've requested a review from another user
