### PR TITLE
fix: remove environment specification from wrangler action in deployment config

### DIFF
--- a/.github/workflows/deploy-client-production.yml
+++ b/.github/workflows/deploy-client-production.yml
@@ -77,7 +77,6 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          environment: client-production
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy client/out --project-name=uasc
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


# Description

We should not set the environment flag because we are not using any of the cloudflare worker secrets - please see https://github.com/cloudflare/wrangler-action?tab=readme-ov-file#configuration

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I have written a storybook for frontend components (if applicable)
- [ ] I've requested a review from another user
