### PR TITLE
feat: add PortableTextRenderer for consistent rich text styling and replace direct PortableText usage

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,15 @@
     "enabled": true,
     "rules": {
       "style": {
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "off",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "@portabletext/react": "DO NOT import PortableText directly from '@portabletext/react'. Use PortableTextRenderer instead for consistent styling and accessibility"
+            }
+          }
+        }
       },
       "recommended": true,
       "correctness": {

--- a/biome.json
+++ b/biome.json
@@ -40,7 +40,10 @@
           "level": "error",
           "options": {
             "paths": {
-              "@portabletext/react": "DO NOT import PortableText directly from '@portabletext/react'. Use PortableTextRenderer instead for consistent styling and accessibility"
+              "@portabletext/react": {
+                "importNames": ["PortableText"],
+                "message": "DO NOT import PortableText directly from '@portabletext/react'. Use PortableTextRenderer instead for consistent styling and accessibility"
+              }
             }
           }
         }

--- a/client/src/app/bookings/page.tsx
+++ b/client/src/app/bookings/page.tsx
@@ -49,7 +49,7 @@ const BookingPage = async () => {
     return {
       ...policy,
       information: policy.information ? (
-        <span className="text-white">
+        <span>
           <PortableTextRenderer
             value={policy.information}
             headerColorClass={"white"}

--- a/client/src/app/bookings/page.tsx
+++ b/client/src/app/bookings/page.tsx
@@ -1,4 +1,4 @@
-import { PortableText } from "@portabletext/react"
+import PortableTextRenderer from "@/components/utils/PortableTextRenderer"
 import type { PolicyWithTextBlocks } from "@/components/composite/Booking/BookingContext"
 import BookingInformationAndCreation from "@/components/composite/Booking/BookingInformationAndCreation/BookingInformationAndCreation"
 import {
@@ -30,7 +30,7 @@ const BookingPage = async () => {
   const RenderedContent = () => {
     return (
       lodgeInfoSingleton?.information && (
-        <PortableText value={lodgeInfoSingleton.information} />
+        <PortableTextRenderer value={lodgeInfoSingleton.information} />
       )
     )
   }
@@ -49,7 +49,13 @@ const BookingPage = async () => {
     return {
       ...policy,
       information: policy.information ? (
-        <PortableText value={policy.information} />
+        <span className="text-white">
+          <PortableTextRenderer
+            value={policy.information}
+            headerColorClass={"white"}
+            textColorClass={"white"}
+          />
+        </span>
       ) : (
         <></>
       )

--- a/client/src/components/utils/PortableTextRenderer.tsx
+++ b/client/src/components/utils/PortableTextRenderer.tsx
@@ -1,0 +1,135 @@
+// DO NOT import PortableText directly from '@portabletext/react'. Use PortableTextRenderer instead for consistent styling and accessibility.
+// import { PortableText } from "@portabletext/react" // Restricted: Use PortableTextRenderer
+
+import {
+  PortableText,
+  type PortableTextBlock,
+  type PortableTextComponents
+  // biome-ignore lint/style/noRestrictedImports: this is the only place it is allowed to be used
+} from "@portabletext/react"
+
+interface PortableTextRendererProps {
+  value: PortableTextBlock[]
+  headerColorClass?: string
+  textColorClass?: string
+}
+
+const getHeaderColor = (headerColorClass?: string) =>
+  headerColorClass || "text-dark-blue-100"
+const getTextColor = (textColorClass?: string) => textColorClass || "text-black"
+
+const getComponents = (
+  headerColorClass?: string,
+  textColorClass?: string
+): PortableTextComponents => ({
+  types: {},
+  marks: {
+    strong: ({ children }) => (
+      <strong className={`font-bold ${getTextColor(textColorClass)}`}>
+        {children}
+      </strong>
+    ),
+    em: ({ children }) => (
+      <em className={`italic ${getTextColor(textColorClass)}`}>{children}</em>
+    ),
+    link: ({ value, children }) => (
+      <a
+        href={value?.href}
+        className={`text-light-blue-100 underline hover:text-orange focus:outline focus:outline-2 focus:outline-orange ${getTextColor(textColorClass)}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </a>
+    )
+  },
+  block: {
+    h1: ({ children }) => (
+      <h1
+        className={`text-h1 font-black mb-4 ${getHeaderColor(headerColorClass)}`}
+      >
+        {children}
+      </h1>
+    ),
+    h2: ({ children }) => (
+      <h2
+        className={`text-h2 font-bold mb-3 ${getHeaderColor(headerColorClass)}`}
+      >
+        {children}
+      </h2>
+    ),
+    h3: ({ children }) => (
+      <h3
+        className={`text-h3 font-bold mb-2 ${getHeaderColor(headerColorClass)}`}
+      >
+        {children}
+      </h3>
+    ),
+    h4: ({ children }) => (
+      <h4
+        className={`text-h4 font-medium mb-2 ${getHeaderColor(headerColorClass)}`}
+      >
+        {children}
+      </h4>
+    ),
+    h5: ({ children }) => (
+      <h5
+        className={`text-h5 font-medium mb-2 ${getHeaderColor(headerColorClass)}`}
+      >
+        {children}
+      </h5>
+    ),
+    normal: ({ children }) => (
+      <p
+        className={`text-p mb-2 leading-relaxed ${getTextColor(textColorClass)}`}
+      >
+        {children}
+      </p>
+    )
+  },
+  list: {
+    bullet: ({ children }) => (
+      <ul
+        className={`list-disc pl-6 mb-2 leading-relaxed ${getTextColor(textColorClass)}`}
+      >
+        {children}
+      </ul>
+    ),
+    number: ({ children }) => (
+      <ol
+        className={`list-decimal pl-6 mb-2 leading-relaxed ${getTextColor(textColorClass)}`}
+      >
+        {children}
+      </ol>
+    )
+  },
+  listItem: {
+    bullet: ({ children }) => (
+      <li
+        className={`mb-1 leading-relaxed text-p ${getTextColor(textColorClass)}`}
+      >
+        {children}
+      </li>
+    ),
+    number: ({ children }) => (
+      <li
+        className={`mb-1 leading-relaxed text-p ${getTextColor(textColorClass)}`}
+      >
+        {children}
+      </li>
+    )
+  }
+})
+
+export default function PortableTextRenderer({
+  value,
+  headerColorClass,
+  textColorClass
+}: PortableTextRendererProps) {
+  return (
+    <PortableText
+      value={value}
+      components={getComponents(headerColorClass, textColorClass)}
+    />
+  )
+}

--- a/client/src/components/utils/PortableTextRenderer.tsx
+++ b/client/src/components/utils/PortableTextRenderer.tsx
@@ -2,10 +2,10 @@
 // import { PortableText } from "@portabletext/react" // Restricted: Use PortableTextRenderer
 
 import {
+  // biome-ignore lint/style/noRestrictedImports: this is the only place it is allowed to be used
   PortableText,
   type PortableTextBlock,
   type PortableTextComponents
-  // biome-ignore lint/style/noRestrictedImports: this is the only place it is allowed to be used
 } from "@portabletext/react"
 
 interface PortableTextRendererProps {

--- a/client/src/components/utils/PortableTextRenderer.tsx
+++ b/client/src/components/utils/PortableTextRenderer.tsx
@@ -121,6 +121,20 @@ const getComponents = (
   }
 })
 
+/**
+ * Renders portable text content with custom components.
+ *
+ * @param value - Portable text value to render.
+ * @param headerColorClass - Optional. Override for header color Tailwind class. Defaults to "text-dark-blue-100".
+ * @param textColorClass - Optional. Override for text color Tailwind class. Defaults to "text-black".
+ *
+ * @example
+ * <PortableTextRenderer
+ *   value={portableTextValue}
+ *   headerColorClass="text-blue-600" // optional override
+ *   textColorClass="text-gray-800"   // optional override
+ * />
+ */
 export default function PortableTextRenderer({
   value,
   headerColorClass,


### PR DESCRIPTION
## Enforce Consistent PortableText Usage and Styling

### Summary

This PR introduces and enforces a standardized approach for rendering PortableText content across the codebase, ensuring consistent styling, accessibility, and adherence to the design system.

### Changes

- **Created/Updated `PortableTextRenderer` Component**
  - Centralizes all PortableText rendering logic.
  - Applies Tailwind classes for accessible, readable, and design-system-compliant typography.
  - Supports props for overriding header and text color classes (`headerColorClass`, `textColorClass`).
  - Ensures consistent line height and font styling for paragraphs and list items.

- **Restricted Direct Import of `@portabletext/react`**
  - Added a comment in `PortableTextRenderer.tsx` to warn against direct imports.
  - Updated `biome.json` to add a linter rule (`noRestrictedImports`) that throws an error if `@portabletext/react` is imported outside of the designated renderer component.
  - Provides a clear error message instructing developers to use `PortableTextRenderer` instead.

- **Design System Compliance**
  - All rich text content now uses the same set of Tailwind classes for headings, paragraphs, lists, and links.
  - Ensures accessibility and visual consistency throughout the app.

### Why?

- Prevents inconsistent styling and accessibility issues caused by ad-hoc usage of `@portabletext/react`.
- Makes it easy to update typography and color system-wide by editing a single component.
- Enforces best practices and design

### Before
<img width="804" height="730" alt="image" src="https://github.com/user-attachments/assets/f19fb709-7d89-4801-8f3a-9bf63f57ebf0" />

### After 
<img width="804" height="730" alt="image" src="https://github.com/user-attachments/assets/1b78891e-d494-4982-b977-07e2c9c32ece" />

