### PR TITLE
feat: extend PortableTextRenderer with additional block and mark support and add Storybook examples

### DIFF
--- a/client/src/app/bookings/page.tsx
+++ b/client/src/app/bookings/page.tsx
@@ -1,4 +1,4 @@
-import PortableTextRenderer from "@/components/utils/PortableTextRenderer"
+import PortableTextRenderer from "@/components/utils/PortableTextRender/PortableTextRenderer"
 import type { PolicyWithTextBlocks } from "@/components/composite/Booking/BookingContext"
 import BookingInformationAndCreation from "@/components/composite/Booking/BookingInformationAndCreation/BookingInformationAndCreation"
 import {

--- a/client/src/components/utils/PortableTextRender/PortableTextRenderer.story.tsx
+++ b/client/src/components/utils/PortableTextRender/PortableTextRenderer.story.tsx
@@ -1,0 +1,229 @@
+import PortableTextRenderer from "./PortableTextRenderer"
+import type { PortableTextBlock } from "@portabletext/react"
+
+const sampleValue: PortableTextBlock[] = [
+  {
+    _type: "block",
+    style: "h1",
+    children: [{ _type: "span", text: "Heading 1" }]
+  },
+  {
+    _type: "block",
+    style: "h2",
+    children: [{ _type: "span", text: "Heading 2" }]
+  },
+  {
+    _type: "block",
+    style: "h3",
+    children: [{ _type: "span", text: "Heading 3" }]
+  },
+  {
+    _type: "block",
+    style: "h4",
+    children: [{ _type: "span", text: "Heading 4" }]
+  },
+  {
+    _type: "block",
+    style: "h5",
+    children: [{ _type: "span", text: "Heading 5" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text: "Normal paragraph text." }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    children: [
+      { _type: "span", marks: ["strong"], text: "Bold text. " },
+      { _type: "span", marks: ["em"], text: "Italic text. " },
+      {
+        _type: "span",
+        marks: ["link"],
+        text: "Link text.",
+        markDefs: [{ _key: "link", _type: "link", href: "https://example.com" }]
+      }
+    ]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text: "List below:" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    listItem: "bullet",
+    level: 1,
+    children: [{ _type: "span", text: "Bullet item 1" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    listItem: "bullet",
+    level: 1,
+    children: [{ _type: "span", text: "Bullet item 2" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    listItem: "number",
+    level: 1,
+    children: [{ _type: "span", text: "Numbered item 1" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    listItem: "number",
+    level: 1,
+    children: [{ _type: "span", text: "Numbered item 2" }]
+  }
+]
+
+const allElementsValue: PortableTextBlock[] = [
+  {
+    _type: "block",
+    style: "h1",
+    children: [{ _type: "span", text: "Heading 1" }]
+  },
+  {
+    _type: "block",
+    style: "h2",
+    children: [{ _type: "span", text: "Heading 2" }]
+  },
+  {
+    _type: "block",
+    style: "h3",
+    children: [{ _type: "span", text: "Heading 3" }]
+  },
+  {
+    _type: "block",
+    style: "h4",
+    children: [{ _type: "span", text: "Heading 4" }]
+  },
+  {
+    _type: "block",
+    style: "h5",
+    children: [{ _type: "span", text: "Heading 5" }]
+  },
+  {
+    _type: "block",
+    style: "h6",
+    children: [{ _type: "span", text: "Heading 6" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text: "Paragraph text." }]
+  },
+  {
+    _type: "block",
+    style: "blockquote",
+    children: [{ _type: "span", text: "Blockquote text." }]
+  },
+  {
+    _type: "block",
+    style: "pre",
+    children: [{ _type: "span", text: "Preformatted code block." }]
+  },
+  {
+    _type: "block",
+    style: "code",
+    children: [{ _type: "span", text: "Inline code." }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    children: [
+      { _type: "span", marks: ["strong"], text: "Bold text. " },
+      { _type: "span", marks: ["em"], text: "Italic text. " },
+      { _type: "span", marks: ["del"], text: "Deleted text. " },
+      { _type: "span", marks: ["ins"], text: "Inserted text. " },
+      { _type: "span", marks: ["sub"], text: "Subscript. " },
+      { _type: "span", marks: ["sup"], text: "Superscript. " },
+      {
+        _type: "span",
+        marks: ["link"],
+        text: "Link text.",
+        markDefs: [{ _key: "link", _type: "link", href: "https://example.com" }]
+      }
+    ]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text: "Horizontal rule below:" }]
+  },
+  { _type: "block", style: "hr", children: [] },
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text: "Bullet list:" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    listItem: "bullet",
+    level: 1,
+    children: [{ _type: "span", text: "Bullet item 1" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    listItem: "bullet",
+    level: 1,
+    children: [{ _type: "span", text: "Bullet item 2" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text: "Numbered list:" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    listItem: "number",
+    level: 1,
+    children: [{ _type: "span", text: "Numbered item 1" }]
+  },
+  {
+    _type: "block",
+    style: "normal",
+    listItem: "number",
+    level: 1,
+    children: [{ _type: "span", text: "Numbered item 2" }]
+  }
+]
+
+export default {
+  title: "Utils/PortableTextRenderer",
+  component: PortableTextRenderer
+}
+
+export const Default = () => <PortableTextRenderer value={sampleValue} />
+
+export const WithHeaderAndTextColorOverride = () => (
+  <PortableTextRenderer
+    value={sampleValue}
+    headerColorClass="text-red-600"
+    textColorClass="text-green-700"
+  />
+)
+
+export const OnlyHeaderColorOverride = () => (
+  <PortableTextRenderer
+    value={sampleValue}
+    headerColorClass="text-purple-600"
+  />
+)
+
+export const OnlyTextColorOverride = () => (
+  <PortableTextRenderer value={sampleValue} textColorClass="text-yellow-700" />
+)
+
+export const EmptyValue = () => <PortableTextRenderer value={[]} />
+
+export const AllElements = () => (
+  <PortableTextRenderer value={allElementsValue} />
+)

--- a/client/src/components/utils/PortableTextRender/PortableTextRenderer.tsx
+++ b/client/src/components/utils/PortableTextRender/PortableTextRenderer.tsx
@@ -41,6 +41,26 @@ const getComponents = (
       >
         {children}
       </a>
+    ),
+    del: ({ children }) => (
+      <del className={`line-through ${getTextColor(textColorClass)}`}>
+        {children}
+      </del>
+    ),
+    ins: ({ children }) => (
+      <ins className={`underline ${getTextColor(textColorClass)}`}>
+        {children}
+      </ins>
+    ),
+    sub: ({ children }) => (
+      <sub className={`align-sub ${getTextColor(textColorClass)}`}>
+        {children}
+      </sub>
+    ),
+    sup: ({ children }) => (
+      <sup className={`align-super ${getTextColor(textColorClass)}`}>
+        {children}
+      </sup>
     )
   },
   block: {
@@ -79,13 +99,42 @@ const getComponents = (
         {children}
       </h5>
     ),
+    h6: ({ children }) => (
+      <h6
+        className={`text-h6 font-medium mb-2 ${getHeaderColor(headerColorClass)}`}
+      >
+        {children}
+      </h6>
+    ),
     normal: ({ children }) => (
       <p
         className={`text-p mb-2 leading-relaxed ${getTextColor(textColorClass)}`}
       >
         {children}
       </p>
-    )
+    ),
+    blockquote: ({ children }) => (
+      <blockquote
+        className={`border-l-4 pl-4 italic mb-2 ${getTextColor(textColorClass)}`}
+      >
+        {children}
+      </blockquote>
+    ),
+    pre: ({ children }) => (
+      <pre
+        className={`bg-gray-100 p-2 rounded mb-2 ${getTextColor(textColorClass)}`}
+      >
+        <code>{children}</code>
+      </pre>
+    ),
+    code: ({ children }) => (
+      <code
+        className={`bg-gray-200 px-1 rounded ${getTextColor(textColorClass)}`}
+      >
+        {children}
+      </code>
+    ),
+    hr: () => <hr className="my-4 border-gray-300" />
   },
   list: {
     bullet: ({ children }) => (


### PR DESCRIPTION
# Enhance PortableTextRenderer with Full HTML Text Element Support & Storybook Coverage

## Summary
This PR significantly improves the PortableTextRenderer component by adding support for every possible HTML text element, ensuring comprehensive rendering of rich text content. Additionally, new Storybook stories have been created to demonstrate and verify the rendering of all supported elements and edge cases.

## Changes

### PortableTextRenderer Enhancements:
- Added support for all HTML text elements:
  - Headings (h1–h6)
  - Paragraphs (p)
  - Blockquotes (blockquote)
  - Preformatted text (pre)
  - Inline code (code)
  - Horizontal rules (hr)
  - Bold (strong)
  - Italic (em)
  - Deleted (del)
  - Inserted (ins)
  - Subscript (sub)
  - Superscript (sup)
  - Links (a)
  - Lists (bulleted and numbered)
- Updated JSDoc documentation to clarify optional color override props.

### Storybook Coverage:
- Added a new AllElements story to demonstrate every supported HTML text element.
- Existing stories now cover:
  - Default rendering
  - Header and text color overrides
  - Only header or text color override
  - Empty value case

## Motivation
- Ensures that all rich text content from Sanity or other sources is rendered accurately and accessibly.
- Provides clear documentation and visual verification for developers via Storybook.

## Testing
- Verified all stories render correctly in Storybook.
- Confirmed that all supported HTML elements display as expected with and without color overrides.

<img width="1139" height="695" alt="image" src="https://github.com/user-attachments/assets/469d91f7-79d2-4958-87d5-75e254005f7c" />
