### PR TITLE
fix: make server deployment manual by updating workflow condition

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   deploy-server:
     name: Deploy Server
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.workflow == 'deploy-server')
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.workflow == 'deploy-server'
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.environment  || 'server-staging' }}


### PR DESCRIPTION
# Description

Currently we are getting a lot of staging builds failing because of a race condition of the server deploying while the client is also building. This change makes sure that all server deployments have do be performed manually

Fixes # (issue)

## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I have written a storybook for frontend components (if applicable)
- [ ] I've requested a review from another user
